### PR TITLE
Use constants for errors

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,6 +23,41 @@ const HEADERS = [
 
 const HEADERS_LOWERCASE = HEADERS.map((header) => header.toLowerCase());
 
+const ERRORS = {
+    MISSING_OFFSET: {
+        status_code: 403,
+        body: 'Upload-Offset header required\n',
+    },
+    INVALID_CONTENT_TYPE: {
+        status_code: 403,
+        body: 'Content-Type header required\n',
+    },
+    FILE_NOT_FOUND: {
+        status_code: 404,
+        body: 'The file for this url was not found\n',
+    },
+    INVALID_OFFSET: {
+        status_code: 409,
+        body: 'Upload-Offset conflict\n',
+    },
+    FILE_NO_LONGER_EXISTS: {
+        status_code: 410,
+        body: 'The file for this url no longer exists\n',
+    },
+    INVALID_LENGTH: {
+        status_code: 412,
+        body: 'Upload-Length or Upload-Defer-Length header required\n',
+    },
+    UNKNOWN_ERROR: {
+        status_code: 500,
+        body: 'Something went wrong with that request\n',
+    },
+    FILE_WRITE_ERROR: {
+        status_code: 500,
+        body: 'Something went wrong receiving the file\n',
+    },
+};
+
 module.exports = {
     TUS_RESUMABLE: '1.0.0',
     TUS_VERSION: ['1.0.0'],
@@ -31,4 +66,5 @@ module.exports = {
     ALLOWED_METHODS: METHODS.join(', '),
     ALLOWED_HEADERS: HEADERS.join(', '),
     MAX_AGE: 86400,
+    ERRORS,
 };

--- a/lib/handlers/HeadHandler.js
+++ b/lib/handlers/HeadHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseHandler = require('./BaseHandler');
+const ERRORS = require('../constants').ERRORS;
 
 class HeadHandler extends BaseHandler {
     /**
@@ -14,7 +15,7 @@ class HeadHandler extends BaseHandler {
         const re = new RegExp('\\' + this.store.path + '\\/(\\S+)\/?'); // eslint-disable-line prefer-template
         const match = req.url.match(re);
         if (!match) {
-            return super.send(res, 404);
+            return super.send(res, ERRORS.FILE_NOT_FOUND.status_code, {}, ERRORS.FILE_NOT_FOUND.body);
         }
 
         const file_id = match[1];
@@ -50,11 +51,12 @@ class HeadHandler extends BaseHandler {
                 return res.end();
             })
             .catch((error) => {
-                if (Number.isInteger(error)) {
-                    return super.send(res, error);
+                console.warn('[HeadHandler]', error);
+                if ('status_code' in error) {
+                    return super.send(res, error.status_code, {}, error.body);
                 }
 
-                return super.send(res, 500);
+                return super.send(res, ERRORS.UNKNOWN_ERROR.status_code, {}, `${ERRORS.UNKNOWN_ERROR.body}${error.message || ''}\n`);
             });
     }
 }

--- a/lib/handlers/PatchHandler.js
+++ b/lib/handlers/PatchHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseHandler = require('./BaseHandler');
+const ERRORS = require('../constants').ERRORS;
 
 class PatchHandler extends BaseHandler {
     /**
@@ -21,13 +22,13 @@ class PatchHandler extends BaseHandler {
         // The request MUST include a Upload-Offset header
         let offset = req.headers['upload-offset'];
         if (offset === undefined) {
-            return super.send(res, 403, {}, 'Upload-Offset Required\n');
+            return super.send(res, ERRORS.MISSING_OFFSET.status_code, {}, ERRORS.MISSING_OFFSET.body);
         }
 
         // The request MUST include a Content-Type header
         const content_type = req.headers['content-type'];
         if (content_type === undefined) {
-            return super.send(res, 403, {}, 'Content-Type Required\n');
+            return super.send(res, ERRORS.INVALID_CONTENT_TYPE.status_code, {}, ERRORS.INVALID_CONTENT_TYPE.body);
         }
 
         offset = parseInt(offset, 10);
@@ -37,7 +38,7 @@ class PatchHandler extends BaseHandler {
                 if (stats.size !== offset) {
                     // If the offsets do not match, the Server MUST respond with the 409 Conflict status without modifying the upload resource.
                     console.warn(`[PatchHandler] send: Incorrect offset - ${offset} sent but file is ${stats.size}`);
-                    return Promise.reject(409);
+                    return Promise.reject(ERRORS.INVALID_OFFSET);
                 }
 
                 return this.store.write(req, file_id, offset);
@@ -51,11 +52,12 @@ class PatchHandler extends BaseHandler {
                 return super.send(res, 204, headers);
             })
             .catch((error) => {
-                if (Number.isInteger(error)) {
-                    return super.send(res, error);
+                console.warn('[PatchHandler]', error);
+                if ('status_code' in error) {
+                    return super.send(res, error.status_code, {}, error.body);
                 }
 
-                return super.send(res, 500);
+                return super.send(res, ERRORS.UNKNOWN_ERROR.status_code, {}, `${ERRORS.UNKNOWN_ERROR.body}${error.message || ''}\n`);
             });
     }
 }

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseHandler = require('./BaseHandler');
+const ERRORS = require('../constants').ERRORS;
 
 class PostHandler extends BaseHandler {
     /**
@@ -17,15 +18,12 @@ class PostHandler extends BaseHandler {
                 return super.send(res, 201, { Location: url });
             })
             .catch((error) => {
-                if (Number.isInteger(error)) {
-                    if (error === 412) {
-                        return super.send(res, error, {}, 'Upload-Length or Upload-Defer-Length Required\n');
-                    }
-
-                    return super.send(res, error);
+                console.warn('[PostHandler]', error);
+                if ('status_code' in error) {
+                    return super.send(res, error.status_code, {}, error.body);
                 }
 
-                return super.send(res, 500);
+                return super.send(res, ERRORS.UNKNOWN_ERROR.status_code, {}, `${ERRORS.UNKNOWN_ERROR.body}${error.message || ''}\n`);
             });
     }
 }

--- a/lib/stores/DataStore.js
+++ b/lib/stores/DataStore.js
@@ -9,6 +9,7 @@
 
 const Uid = require('../models/Uid');
 const File = require('../models/File');
+const ERRORS = require('../constants').ERRORS;
 
 class DataStore {
     constructor(options) {
@@ -46,15 +47,13 @@ class DataStore {
      * @return {Promise}
      */
     create(req) {
-        console.log('[DataStore] create');
-
         return new Promise((resolve, reject) => {
             const upload_length = req.headers['upload-length'];
             const upload_defer_length = req.headers['upload-defer-length'];
             const upload_metadata = req.headers['upload-metadata'];
 
             if (upload_length === undefined && upload_defer_length === undefined) {
-                return reject(412);
+                return reject(ERRORS.INVALID_LENGTH);
             }
 
             const file_id = this.generateFileName(req);
@@ -94,7 +93,7 @@ class DataStore {
     getOffset(id) {
         return new Promise((resolve, reject) => {
             if (!id) {
-                return reject(404);
+                return reject(ERRORS.FILE_NOT_FOUND);
             }
             return resolve({ size: 0, upload_length: 1 });
         });

--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -8,6 +8,7 @@ const pkg = require('../../package.json');
 const MASK = '0777';
 const IGNORED_MKDIR_ERROR = 'EEXIST';
 const FILE_DOESNT_EXIST = 'ENOENT';
+const ERRORS = require('../constants').ERRORS;
 
 
 /**
@@ -53,7 +54,7 @@ class FileStore extends DataStore {
             const upload_metadata = req.headers['upload-metadata'];
 
             if (upload_length === undefined && upload_defer_length === undefined) {
-                return reject(412);
+                return reject(ERRORS.INVALID_LENGTH);
             }
 
             let file_id;
@@ -62,7 +63,7 @@ class FileStore extends DataStore {
             }
             catch (generateError) {
                 console.warn('[FileStore] create: check your namingFunction. Error', generateError);
-                return reject(500);
+                return reject(ERRORS.FILE_WRITE_ERROR);
             }
 
             const file = new File(file_id, upload_length, upload_defer_length, upload_metadata);
@@ -106,7 +107,7 @@ class FileStore extends DataStore {
             const stream = fs.createWriteStream(path, options);
 
             if (!stream) {
-                return reject(500);
+                return reject(ERRORS.FILE_WRITE_ERROR);
             }
 
             let new_offset = 0;
@@ -123,7 +124,7 @@ class FileStore extends DataStore {
 
             stream.on('error', (e) => {
                 console.warn('[FileStore] write: Error', e);
-                reject(500);
+                reject(ERRORS.FILE_WRITE_ERROR);
             });
 
             return req.pipe(stream);
@@ -143,16 +144,15 @@ class FileStore extends DataStore {
             fs.stat(file_path, (error, stats) => {
                 if (error && error.code === FILE_DOESNT_EXIST && config) {
                     console.warn(`[FileStore] getOffset: No file found at ${file_path} but db record exists`, config);
-                    return reject(410);
+                    return reject(ERRORS.FILE_NO_LONGER_EXISTS);
                 }
 
                 if (error && error.code === FILE_DOESNT_EXIST) {
                     console.warn(`[FileStore] getOffset: No file found at ${file_path}`);
-                    return reject(404);
+                    return reject(ERRORS.FILE_NOT_FOUND);
                 }
 
                 if (error) {
-                    console.warn(error);
                     return reject(error);
                 }
 


### PR DESCRIPTION
Starting point for consolidating error handling. The `catch` parts of each handler could be more DRY.

Closes #31 
