### PR TITLE
Remove HTTP as part of POST handler response

### DIFF
--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -15,7 +15,7 @@ class PostHandler extends BaseHandler {
     send(req, res) {
         return this.store.create(req)
             .then((File) => {
-                const url = `http://${req.headers.host}${this.store.path}/${File.id}`;
+                const url = `//${req.headers.host}${this.store.path}/${File.id}`;
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
                 return super.send(res, 201, { Location: url });
             })


### PR DESCRIPTION
Removes `http://` prefix from POST handler response

Fixes #48 