### PR TITLE
MongoDB GridFS Backend Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ files/
 
 *.sublime-workspace
 
+# IDEA
+.idea
+
 # Keyfile will be decrypted from keyfile.json.enc by travis
 # https://docs.travis-ci.com/user/encrypting-files/
 test/keyfile.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ files/
 
 *.sublime-workspace
 
-# IDEA
+# IDEA / Webstorm
 .idea
 
 # Keyfile will be decrypted from keyfile.json.enc by travis

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Server = require('./lib/Server');
 const DataStore = require('./lib/stores/DataStore');
 const FileStore = require('./lib/stores/FileStore');
 const GCSDataStore = require('./lib/stores/GCSDataStore');
+const MongoGridFSStore = require('./lib/stores/MongoGridFSStore');
 const EVENTS = require('./lib/constants').EVENTS;
 
 module.exports = {
@@ -11,5 +12,6 @@ module.exports = {
     DataStore,
     FileStore,
     GCSDataStore,
+    MongoGridFSStore
     EVENTS,
 };

--- a/index.js
+++ b/index.js
@@ -12,6 +12,6 @@ module.exports = {
     DataStore,
     FileStore,
     GCSDataStore,
-    MongoGridFSStore
+    MongoGridFSStore,
     EVENTS,
 };

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -118,7 +118,7 @@ class MongoGridFSStore extends DataStore {
         {
             this.db.then((db) => {
                 const chunks = db.collection(`${this.bucket_name}.chunks`);
-                this.files = db.collection(`${this.bucket_name}.files`);
+                const files = db.collection(`${this.bucket_name}.files`);
 
                 files.findOne({_id: new mongodb.ObjectID(file_id)}).then((fileData) =>
                 {
@@ -178,8 +178,6 @@ class MongoGridFSStore extends DataStore {
                         });
     
                         req.on('end', () => {
-                            console.log(`${new_offset} bytes written`);
-    
                             if (fileData.metadata.upload_length === new_offset) {
                                 this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, {file: fileData});
                             }
@@ -188,7 +186,7 @@ class MongoGridFSStore extends DataStore {
                         });
     
                         chunker.on('error', (e) => {
-                            console.log(e);
+                            console.warn(e);
                             reject(ERRORS.FILE_WRITE_ERROR);
                         });
     

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const DataStore = require('./DataStore');
+const File = require('../models/File');
+const mongodb = require('mongodb');
+const assign = require('object-assign');
+const chunkingStreams = require('chunking-streams');
+const SparkMD5 = require('spark-md5');
+const stream = require('stream');
+const ERRORS = require('../constants').ERRORS;
+const EVENTS = require('../constants').EVENTS;
+const TUS_RESUMABLE = require('../constants').TUS_RESUMABLE;
+const DEFAULT_CONFIG = {
+    scopes: ['https://www.googleapis.com/auth/devstorage.full_control'],
+};
+
+
+/**
+ * @fileOverview
+ * A Store that is backed by a MongoDB, using its GridFS feature.
+ *
+ * See https://docs.mongodb.com/manual/core/gridfs/ and
+ * http://mongodb.github.io/node-mongodb-native/2.2/tutorials/gridfs/streaming/
+ * for more information.
+ *
+ * @author Bradley Arsenault <brad@electricbrain.io>
+ */
+
+class MongoGridFSStore extends DataStore {
+    /**
+     * Construct the MongoGridFSStore.
+     *
+     * @param {object} options An object containing all of the options for the store
+     * @param {string} options.uri The URI for the Mongo database. Must be in the form of mongodb://localhost/database_name
+     * @param {string} options.bucket The name of the bucket to store the files in under Mongo. Mongo GridFS creates two collections from your bucket name.
+     * @param {number} options.chunk_size The chunk size, in bytes, for the files in MongoDB. Defaults to 64kb
+     */
+    constructor(options) {
+        super(options);
+        this.extensions = ['creation', 'creation-defer-length'];
+
+        if (!options.uri) {
+            throw new Error('MongoGridFSStore must be provided with the URI for the Mongo database!');
+        }
+        if (!options.bucket) {
+            throw new Error('MongoGridFSStore must be provided with a bucket name to store the files in within Mongo!');
+        }
+        this.bucket_name = options.bucket;
+        this.chunk_size = options.chunk_size || (1024 * 64);
+
+        this.db = mongodb.MongoClient.connect(options.uri);
+    }
+
+
+    /**
+     * Create an empty file in Mongo to store the metadata.
+     *
+     * @param  {object} req http.incomingMessage
+     * @return {Promise}
+     */
+    create(req) {
+        return new Promise((resolve, reject) => {
+            this.db.then((db) => {
+                const upload_length = req.headers['upload-length'];
+                const upload_defer_length = req.headers['upload-defer-length'];
+                const upload_metadata = req.headers['upload-metadata'];
+
+                if (upload_length === undefined && upload_defer_length === undefined) {
+                    reject(ERRORS.INVALID_LENGTH);
+                    return;
+                }
+
+                let file_id = new mongodb.ObjectID();
+
+                const file = new File(file_id.toString(), upload_length, upload_defer_length, upload_metadata);
+
+                const md5 = new SparkMD5();
+
+                const grid_file = {
+                    "_id" : file_id,
+                    "length" : 0,
+                    "chunkSize" : this.chunk_size,
+                    "uploadDate" : new Date(),
+                    "filename": "file",
+                    "md5": md5.end(),
+                    "metadata" : {
+                        upload_length: file.upload_length,
+                        tus_version: TUS_RESUMABLE,
+                        upload_metadata,
+                        upload_defer_length,
+                        md5state: md5.getState()
+                    }
+                };
+
+                const files = db.collection(`${this.bucket_name}.files`);
+                files.insertOne(grid_file).then((result) => {
+                    this.emit(EVENTS.EVENT_FILE_CREATED, { file });
+                    resolve(file);
+                }, (err) => {
+                    reject(err);
+                });
+            });
+        });
+    }
+
+    /**
+     * Get the file metadata from the object in GCS, then upload a new version
+     * passing through the metadata to the new version.
+     *
+     * @param  {object} req         http.incomingMessage
+     * @param  {string} file_id     Name of file
+     * @param  {integer} offset     starting offset
+     * @return {Promise}
+     */
+    write(req, file_id, offset) {
+        // Get the current file object from MongoDB
+        return new Promise((resolve, reject) =>
+        {
+            this.db.then((db) => {
+                const chunks = db.collection(`${this.bucket_name}.chunks`);
+                this.files = db.collection(`${this.bucket_name}.files`);
+
+                files.findOne({_id: new mongodb.ObjectID(file_id)}).then((fileData) =>
+                {
+                    if (!fileData)
+                    {
+                        return reject(ERRORS.FILE_NOT_FOUND);
+                    }
+    
+                    // If the offset is above 0, then we fetch that chunk
+                    // to use as a starting point. Otherwise we create a
+                    // brand new chunk.
+                    const startingChunkIndex = Math.floor(offset / this.chunk_size);
+                    let startingChunkPromise = Promise.resolve(null);
+                    if (offset > 0) {
+                        startingChunkPromise = chunks.findOne({"files_id": new mongodb.ObjectID(file_id), n: startingChunkIndex});
+                    }
+    
+                    const md5 = new SparkMD5();
+                    md5.setState(fileData.metadata.md5state);
+                    startingChunkPromise.then((startingChunk) => {
+                        const chunker = new chunkingStreams.SizeChunker({
+                            chunkSize: this.chunk_size
+                        });
+    
+                        chunker.on('data', (chunk, callback) => {
+                            chunks.updateOne({
+                                "files_id": new mongodb.ObjectID(file_id),
+                                "n": startingChunkIndex + chunk.id
+                            }, {
+                                "files_id": new mongodb.ObjectID(file_id),
+                                "n": startingChunkIndex + chunk.id,
+                                "data": chunk.data
+                            }, {upsert: true}).then((result) => {
+                                fileData.length += chunk.data.length;
+                                md5.append(chunk.data);
+                                fileData.md5 = md5.end();
+                                files.updateOne({
+                                    "_id": new mongodb.ObjectID(file_id)
+                                }, fileData).then((result) => {
+                                    return callback(null, result);
+                                }, (err) => {
+                                    return callback(err);
+                                });
+                            }, (err) => {
+                                return callback(err);
+                            });
+                        });
+    
+                        // If there is a starting chunk, write all of its data to the chunker
+                        if (startingChunk) {
+                            chunker.write(startingChunk.data);
+                        }
+    
+                        let new_offset = 0;
+                        req.on('data', (buffer) => {
+                            new_offset += buffer.length;
+                        });
+    
+                        req.on('end', () => {
+                            console.log(`${new_offset} bytes written`);
+    
+                            if (fileData.metadata.upload_length === new_offset) {
+                                this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, {file: fileData});
+                            }
+    
+                            resolve(new_offset);
+                        });
+    
+                        chunker.on('error', (e) => {
+                            console.log(e);
+                            reject(ERRORS.FILE_WRITE_ERROR);
+                        });
+    
+                        return req.pipe(chunker);
+                    });
+                }, (error) => {
+                    console.warn('[MongoGridFSStore] write', error);
+                    return reject(ERRORS.FILE_WRITE_ERROR);
+                });
+            }, (error) => {
+                console.warn('[MongoGridFSStore] write', error);
+                return reject(ERRORS.FILE_WRITE_ERROR);
+            });
+        });
+    }
+
+    /**
+     * Get file metadata from the object in MongoDB
+     *
+     * @param  {string} file_id     name of the file
+     * @return {object}
+     */
+    getOffset(file_id) {
+        return new Promise((resolve, reject) => {
+            this.db.then((db) => {
+                let _id;
+                try {
+                    _id = new mongodb.ObjectID(file_id);
+                }
+                catch(err) {
+                    reject(err);
+                }
+
+                const files = db.collection(`${this.bucket_name}.files`);
+                files.findOne({_id}).then((fileData) => {
+                    if (!fileData) {
+                        return reject(ERRORS.FILE_NOT_FOUND);
+                    }
+
+
+                    const data = {
+                        size: fileData.length
+                    };
+
+                    if (!('metadata' in fileData)) {
+                        return resolve(data);
+                    }
+
+                    if (fileData.metadata.upload_length) {
+                        data.upload_length = fileData.metadata.upload_length;
+                    }
+
+                    if (fileData.metadata.upload_defer_length) {
+                        data.upload_defer_length = fileData.metadata.upload_defer_length;
+                    }
+
+                    if (fileData.metadata.upload_metadata) {
+                        data.upload_metadata = fileData.metadata.upload_metadata;
+                    }
+
+                    return resolve(data);
+                }, (error) => {
+                    console.warn('[MongoGridFSStore] getFileMetadata', error);
+                    return reject(error);
+                });
+            });
+        });
+    }
+}
+
+module.exports = MongoGridFSStore;

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -130,8 +130,7 @@ class MongoGridFSStore extends DataStore {
 
                 files.findOne({_id: new mongodb.ObjectID(file_id)}).then((fileData) =>
                 {
-                    if (!fileData)
-                    {
+                    if (!fileData) {
                         return reject(ERRORS.FILE_NOT_FOUND);
                     }
     
@@ -139,6 +138,7 @@ class MongoGridFSStore extends DataStore {
                     // to use as a starting point. Otherwise we create a
                     // brand new chunk.
                     const startingChunkIndex = Math.floor(offset / this.chunk_size);
+                    const startingChunkData = offset % this.chunk_size;
                     let startingChunkPromise = Promise.resolve(null);
                     if (offset > 0) {
                         startingChunkPromise = chunks.findOne({"files_id": new mongodb.ObjectID(file_id), n: startingChunkIndex});
@@ -146,6 +146,7 @@ class MongoGridFSStore extends DataStore {
     
                     const md5 = new SparkMD5();
                     md5.setState(fileData.metadata.md5state);
+                    let fileSize = startingChunkIndex * this.chunk_size;
                     startingChunkPromise.then((startingChunk) => {
                         const chunker = new chunkingStreams.SizeChunker({
                             chunkSize: this.chunk_size,
@@ -167,7 +168,8 @@ class MongoGridFSStore extends DataStore {
                                 "n": startingChunkIndex + id,
                                 "data": buffer
                             }, {upsert: true}).then((result) => {
-                                fileData.length += buffer.length;
+                                fileSize += buffer.length;
+                                fileData.length = fileSize;
                                 fileData.md5 = md5.end();
                                 fileData.metadata.md5state = md5.getState();
                                 files.updateOne({
@@ -184,33 +186,38 @@ class MongoGridFSStore extends DataStore {
 
                         chunker.on('data', (chunk) => {
                             buffer = Buffer.concat([buffer, chunk.data]);
-                            md5.append(chunk.data);
                         });
 
                         // If there is a starting chunk, write all of its data to the chunker
                         if (startingChunk) {
-                            chunker.write(startingChunk.data);
+                            chunker.write(startingChunk.data.buffer.slice(0, startingChunkData));
                         }
     
                         let new_offset = offset;
                         req.on('data', (buffer) => {
                             new_offset += buffer.length;
+                            md5.append(buffer);
+                            chunker.write(buffer);
                         });
-    
+
                         req.on('end', () => {
                             if (fileData.metadata.upload_length === new_offset) {
                                 this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, {file: fileData});
                             }
-    
-                            resolve(new_offset);
+
+                            chunker.end((err) => {
+                                if (err) {
+                                    return reject(err);
+                                }
+
+                                return resolve(new_offset);
+                            });
                         });
-    
+
                         chunker.on('error', (e) => {
                             console.warn(e);
                             reject(ERRORS.FILE_WRITE_ERROR);
                         });
-    
-                        return req.pipe(chunker);
                     }, (error) => {
                         console.warn('[MongoGridFSStore] write', error);
                         return reject(ERRORS.FILE_WRITE_ERROR);

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -192,7 +192,7 @@ class MongoGridFSStore extends DataStore {
                             chunker.write(startingChunk.data);
                         }
     
-                        let new_offset = 0;
+                        let new_offset = offset;
                         req.on('data', (buffer) => {
                             new_offset += buffer.length;
                         });

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -48,7 +48,15 @@ class MongoGridFSStore extends DataStore {
         this.bucket_name = options.bucket;
         this.chunk_size = options.chunk_size || (1024 * 64);
 
-        this.db = mongodb.MongoClient.connect(options.uri);
+        this.db = mongodb.MongoClient.connect(options.uri).then((db) => {
+            const chunks = db.collection(`${this.bucket_name}.chunks`);
+            const files = db.collection(`${this.bucket_name}.files`);
+
+            return chunks.createIndex({files_id: 1, n: 1}).then(() =>
+            {
+                return db;
+            });
+        });
     }
 
 

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -142,18 +142,24 @@ class MongoGridFSStore extends DataStore {
                         const chunker = new chunkingStreams.SizeChunker({
                             chunkSize: this.chunk_size
                         });
-    
-                        chunker.on('data', (chunk, callback) => {
+
+                        let buffer = new Buffer(0);
+                        chunker.on('chunkStart', function(id, callback) {
+                            buffer = new Buffer(0);
+                            return callback();
+                        });
+
+                        chunker.on('chunkEnd', function(id, callback) {
                             chunks.updateOne({
                                 "files_id": new mongodb.ObjectID(file_id),
-                                "n": startingChunkIndex + chunk.id
+                                "n": startingChunkIndex + id
                             }, {
                                 "files_id": new mongodb.ObjectID(file_id),
-                                "n": startingChunkIndex + chunk.id,
-                                "data": chunk.data
+                                "n": startingChunkIndex + id,
+                                "data": buffer
                             }, {upsert: true}).then((result) => {
-                                fileData.length += chunk.data.length;
-                                md5.append(chunk.data);
+                                fileData.length += buffer.length;
+                                md5.append(buffer);
                                 fileData.md5 = md5.end();
                                 files.updateOne({
                                     "_id": new mongodb.ObjectID(file_id)
@@ -166,7 +172,11 @@ class MongoGridFSStore extends DataStore {
                                 return callback(err);
                             });
                         });
-    
+
+                        chunker.on('data', (chunk) => {
+                            buffer = Buffer.concat([buffer, chunk.data]);
+                        });
+
                         // If there is a starting chunk, write all of its data to the chunker
                         if (startingChunk) {
                             chunker.write(startingChunk.data);
@@ -191,6 +201,9 @@ class MongoGridFSStore extends DataStore {
                         });
     
                         return req.pipe(chunker);
+                    }, (error) => {
+                        console.warn('[MongoGridFSStore] write', error);
+                        return reject(ERRORS.FILE_WRITE_ERROR);
                     });
                 }, (error) => {
                     console.warn('[MongoGridFSStore] write', error);

--- a/lib/stores/MongoGridFSStore.js
+++ b/lib/stores/MongoGridFSStore.js
@@ -140,7 +140,8 @@ class MongoGridFSStore extends DataStore {
                     md5.setState(fileData.metadata.md5state);
                     startingChunkPromise.then((startingChunk) => {
                         const chunker = new chunkingStreams.SizeChunker({
-                            chunkSize: this.chunk_size
+                            chunkSize: this.chunk_size,
+                            flushTail: true
                         });
 
                         let buffer = new Buffer(0);
@@ -159,8 +160,8 @@ class MongoGridFSStore extends DataStore {
                                 "data": buffer
                             }, {upsert: true}).then((result) => {
                                 fileData.length += buffer.length;
-                                md5.append(buffer);
                                 fileData.md5 = md5.end();
+                                fileData.metadata.md5state = md5.getState();
                                 files.updateOne({
                                     "_id": new mongodb.ObjectID(file_id)
                                 }, fileData).then((result) => {
@@ -175,6 +176,7 @@ class MongoGridFSStore extends DataStore {
 
                         chunker.on('data', (chunk) => {
                             buffer = Buffer.concat([buffer, chunk.data]);
+                            md5.append(chunk.data);
                         });
 
                         // If there is a starting chunk, write all of its data to the chunker

--- a/package.json
+++ b/package.json
@@ -53,11 +53,14 @@
     "tus-js-client": "^1.1.4"
   },
   "dependencies": {
+    "chunking-streams": "0.0.8",
     "configstore": "^2.0.0",
     "crypto-rand": "0.0.2",
     "google-auto-auth": "^0.2.4",
     "google-cloud": "^0.38.3",
+    "mongodb": "^2.2.11",
     "object-assign": "^4.1.0",
-    "request": "^2.72.0"
+    "request": "^2.72.0",
+    "spark-md5": "^2.0.2"
   }
 }

--- a/test/Test-MongoGridFSStore.js
+++ b/test/Test-MongoGridFSStore.js
@@ -1,0 +1,186 @@
+/* eslint-env node, mocha */
+
+'use strict';
+const should = require('should');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const mongodb = require('mongodb');
+const Server = require('../lib/Server');
+const DataStore = require('../lib/stores/DataStore');
+const MongoGridFSStore = require('../lib/stores/MongoGridFSStore');
+const File = require('../lib/models/File');
+const ERRORS = require('../lib/constants').ERRORS;
+const EVENTS = require('../lib/constants').EVENTS;
+const TUS_RESUMABLE = require('../lib/constants').TUS_RESUMABLE;
+
+const STORE_PATH = '/files';
+const PROJECT_ID = 'vimeo-open-source';
+const KEYFILE = path.resolve(__dirname, 'keyfile.json');
+const BUCKET = 'tus-node-server';
+
+const TEST_FILE_SIZE = 960244;
+const TEST_FILE_PATH = path.resolve(__dirname, 'test.mp4');
+
+let grid_fs = null;
+
+const mongoURI = "mongodb://localhost/tus-unit-test";
+
+describe.only('MongoGridFSStore', () => {
+    let server;
+    let test_file_id;
+    const files_created = [];
+    before(() => {
+        server = new Server();
+        server.datastore = new MongoGridFSStore({
+            path: STORE_PATH,
+            uri: mongoURI,
+            bucket: BUCKET
+        });
+
+        return mongodb.connect(mongoURI).then((db) =>
+        {
+            grid_fs = new mongodb.GridFSBucket(db, {
+                chunkSizeBytes: 1024 * 64,
+                bucketName: BUCKET
+            });
+        });
+    });
+
+    after(() => {
+        // return grid_fs.drop();
+    });
+
+    describe('constructor', () => {
+        it('must require a bucket', () => {
+            assert.throws(() => {
+                new MongoGridFSStore({ uri: mongoURI });
+            }, Error);
+        });
+        
+        it('must require a uri', () => {
+            assert.throws(() => {
+                new MongoGridFSStore({ bucket: BUCKET });
+            }, Error);
+        });
+
+        it('must inherit from Datastore', () => {
+            assert.equal(server.datastore instanceof DataStore, true);
+        });
+
+        it('must have a create method', () => {
+            server.datastore.should.have.property('create');
+        });
+
+        it('must have a write method', () => {
+            server.datastore.should.have.property('write');
+        });
+
+        it('must have a getOffset method', () => {
+            server.datastore.should.have.property('getOffset');
+        });
+    });
+
+    describe('create', () => {
+        it('should reject requests without a length header', () => {
+            const req = {
+                headers: {},
+            };
+            return server.datastore.create(req)
+                .should.be.rejectedWith(ERRORS.INVALID_LENGTH);
+        });
+
+        it('should create a file', (done) => {
+            const req = {
+                headers: {
+                    'upload-length': TEST_FILE_SIZE,
+                },
+            };
+            server.datastore.create(req)
+                .then((file) => {
+                    assert.equal(file instanceof File, true);
+                    assert.equal(file.upload_length, TEST_FILE_SIZE);
+                    test_file_id = file.id;
+                    return done();
+                }).catch(console.log);
+        });
+
+
+        it(`should fire the ${EVENTS.EVENT_FILE_CREATED} event`, (done) => {
+            server.datastore.on(EVENTS.EVENT_FILE_CREATED, (event) => {
+                event.should.have.property('file');
+                assert.equal(event.file instanceof File, true);
+                done();
+            });
+
+            const req = {
+                headers: {
+                    'upload-length': TEST_FILE_SIZE,
+                },
+            };
+            server.datastore.create(req)
+                .catch(console.log);
+        });
+    });
+
+    describe('write', () => {
+        it('should open a stream and resolve the new offset', (done) => {
+            const write_stream = fs.createReadStream(TEST_FILE_PATH);
+            write_stream.once('open', () => {
+                server.datastore.write(write_stream, test_file_id, 0)
+                    .then((offset) => {
+                        files_created.push(test_file_id.split('&upload_id')[0]);
+                        assert.equal(offset, TEST_FILE_SIZE);
+                        return done();
+                    })
+                    .catch(console.log);
+            });
+        });
+
+
+        it(`should fire the ${EVENTS.EVENT_UPLOAD_COMPLETE} event`, (done) => {
+            server.datastore.on(EVENTS.EVENT_UPLOAD_COMPLETE, (event) => {
+                event.should.have.property('file');
+                done();
+            });
+
+            const write_stream = fs.createReadStream(TEST_FILE_PATH);
+            write_stream.once('open', () => {
+                server.datastore.write(write_stream, test_file_id, 0)
+                    .catch(console.log);
+            });
+        });
+    });
+
+    describe('getOffset', () => {
+        it('should reject files with an invalid ID', () => {
+            return server.datastore.getOffset('not_a_file')
+                .should.be.rejectedWith("Argument passed in must be a single String of 12 bytes or a string of 24 hex characters");
+        });
+        it('should reject non existent files', () => {
+            return server.datastore.getOffset(new mongodb.ObjectID())
+                .should.be.rejectedWith(ERRORS.FILE_NOT_FOUND);
+        });
+
+        it('should resolve existing files with the metadata', () => {
+            const stream = grid_fs.openUploadStream("file", {metadata:{
+                upload_length: TEST_FILE_SIZE,
+                tus_version: TUS_RESUMABLE
+            }});
+
+            const data = fs.readFileSync(TEST_FILE_PATH);
+            stream.end(data);
+
+            return new Promise((resolve, reject) =>
+            {
+                stream.once("finish", () => {
+                return resolve(server.datastore.getOffset(stream.id.toString())
+                    .should.be.fulfilledWith({
+                        size: TEST_FILE_SIZE,
+                        upload_length: TEST_FILE_SIZE
+                    }));
+                });
+            });
+        });
+    });
+});

--- a/test/Test-MongoGridFSStore.js
+++ b/test/Test-MongoGridFSStore.js
@@ -26,7 +26,7 @@ let grid_fs = null;
 
 const mongoURI = "mongodb://localhost/tus-unit-test";
 
-describe('MongoGridFSStore', () => {
+describe.only('MongoGridFSStore', () => {
     let server;
     let test_file_id;
     const files_created = [];

--- a/test/Test-MongoGridFSStore.js
+++ b/test/Test-MongoGridFSStore.js
@@ -26,7 +26,7 @@ let grid_fs = null;
 
 const mongoURI = "mongodb://localhost/tus-unit-test";
 
-describe.only('MongoGridFSStore', () => {
+describe('MongoGridFSStore', () => {
     let server;
     let test_file_id;
     const files_created = [];
@@ -48,7 +48,7 @@ describe.only('MongoGridFSStore', () => {
     });
 
     after(() => {
-        // return grid_fs.drop();
+        return grid_fs.drop();
     });
 
     describe('constructor', () => {


### PR DESCRIPTION
I have created an implementation of DataStore that uses MongoDB as its backing client.

Please provide me your comments & changes soon. I would love to be able to get this out into the main line release so I don't have to link to my own fork. 