### PR TITLE
Allow node versions >=6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/tus/tus-node-server#readme",
   "engines": {
-    "node": "6.0"
+    "node": ">=6.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Allows node versions `>=6.0`. When using the `yarn` package manager, it does not allow installation since at the moment tus requires _exactly_ the version 6.0.

This should also be pushed to `npm` since on there the engine version is stuck at `4.4.4`.