### PR TITLE
Add protocol to location header in POSTs

### DIFF
--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -15,7 +15,7 @@ class PostHandler extends BaseHandler {
     send(req, res) {
         return this.store.create(req)
             .then((File) => {
-                const url = `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
+                const url = `http://${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
                 return super.send(res, 201, { Location: url });
             })

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -85,6 +85,7 @@ describe('EndToEnd', () => {
                 .expect(201)
                 .end((err, res) => {
                     assert.equal('location' in res.headers, true);
+                    assert.equal(res.headers['location'].substring(0,7),'http://');
                     assert.equal(res.headers['tus-resumable'], TUS_RESUMABLE);
                     // Save the id for subsequent tests
                     file_to_delete = res.headers.location.split('/').pop();
@@ -101,6 +102,7 @@ describe('EndToEnd', () => {
                 .expect(201)
                 .end((err, res) => {
                     assert.equal('location' in res.headers, true);
+                    assert.equal(res.headers['location'].substring(0,7),'http://');
                     assert.equal(res.headers['tus-resumable'], TUS_RESUMABLE);
                     // Save the id for subsequent tests
                     file_id = res.headers.location.split('/').pop();
@@ -117,6 +119,7 @@ describe('EndToEnd', () => {
                 .expect(201)
                 .end((err, res) => {
                     assert.equal('location' in res.headers, true);
+                    assert.equal(res.headers['location'].substring(0,7),'http://');
                     assert.equal(res.headers['tus-resumable'], TUS_RESUMABLE);
                     // Save the id for subsequent tests
                     deferred_file_id = res.headers.location.split('/').pop();


### PR DESCRIPTION
The protocol in the location header was missing in POST
requests. The protocol is present in tusd.