### PR TITLE
patch url generation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ server.datastore = new tus.FileStore({
 });
 
 var app = express();
-app.all('/files/*', function(req, res) {
-  server.handle(req, res);
-});
+const uploadApp = express();
+uploadApp.all('*', server.handle.bind(server));
+app.use('/uploads', uploadApp);
 app.listen(port, host);
 ```
 

--- a/demo/server.js
+++ b/demo/server.js
@@ -60,6 +60,18 @@ server.on(EVENTS.EVENT_UPLOAD_COMPLETE, (event) => {
     console.log(`[${new Date().toLocaleTimeString()}] [EVENT HOOK] Upload complete for file ${event.file.id}`);
 });
 
+// // this is the express stile ;)
+// const express = require('express');
+// const app = express();
+// // Define routes to serve the demo html/js files.
+// app.get('/', writeFile);
+// app.get('/demo/index.js', writeFile);
+// app.get('/node_modules/tus-js-client/dist/tus.js', writeFile);
+//
+// const uploadApp = express();
+// uploadApp.all('*', server.handle.bind(server));
+// app.use('/uploads', uploadApp);
+
 const host = '127.0.0.1';
 const port = 8000;
 server.listen({ host, port }, () => {

--- a/lib/handlers/BaseHandler.js
+++ b/lib/handlers/BaseHandler.js
@@ -41,7 +41,7 @@ class BaseHandler extends EventEmitter {
      * @return {bool|string}
      */
     getFileIdFromRequest(req) {
-        const re = new RegExp('\\' + this.store.path + '\\/(\\S+)\/?'); // eslint-disable-line prefer-template
+        const re = new RegExp(`${req.baseUrl || this.store.path}\\/(\\S+)\\/?`); // eslint-disable-line prefer-template
         const match = (req.originalUrl || req.url).match(re);
         if (!match) {
             return false;

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -15,7 +15,7 @@ class PostHandler extends BaseHandler {
     send(req, res) {
         return this.store.create(req)
             .then((File) => {
-                const url = `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
+                const url = `//${req.headers.host}${req.baseUrl || this.store.path}/${File.id}`;
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
                 return super.send(res, 201, { Location: url });
             })


### PR DESCRIPTION
When I wanted to use express app for uploading:
```
const uploadApp = express();
uploadApp.all('*', server.handle.bind(server));
mainApp.use('/uploads', uploadApp);
```
it didn't work because generation of patch url was based on filestorage.path which IMHO should not have had nothing to do with url prefix of incomming request.

PS: usage of express would make much more easy even the rest of the app ;) What do you think?