### PR TITLE
Replace configstore with plain json files in upload path

### DIFF
--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -67,7 +67,7 @@ class FileStore extends DataStore {
             }
 
             const file = new File(file_id, upload_length, upload_defer_length, upload_metadata);
-            const filepath = this.binPath(file_id);
+            const filepath = this.filePath(file_id);
 
             return fs.open(filepath, 'w', (err, fd) => {
                 if (err) {
@@ -75,7 +75,14 @@ class FileStore extends DataStore {
                     return reject(err);
                 }
 
-                this.writeConfig(file);
+                try {
+                    this.writeFileInfo(file);
+                }
+                catch (infoWriteError) {
+                    log('[FileStore] create: Info Write Error', infoWriteError);
+                    return reject(infoWriteError);
+                }
+
 
                 return fs.close(fd, (exception) => {
                     if (exception) {
@@ -111,7 +118,7 @@ class FileStore extends DataStore {
      */
     write(req, file_id, offset) {
         return new Promise((resolve, reject) => {
-            const path = this.binPath(file_id);
+            const path = this.filePath(file_id);
             const options = {
                 flags: 'r+',
                 start: offset,
@@ -134,7 +141,7 @@ class FileStore extends DataStore {
                 offset += new_offset;
                 log(`[FileStore] write: File is now ${offset} bytes`);
 
-                const config = this.getConfig(file_id);
+                const config = this.getFileInfo(file_id);
                 if (config && parseInt(config.upload_length, 10) === offset) {
                     this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file: config });
                 }
@@ -150,9 +157,9 @@ class FileStore extends DataStore {
      * @return {object}           fs stats
      */
     getOffset(file_id) {
-        const config = this.getConfig(file_id);
+        const config = this.getFileInfo(file_id);
         return new Promise((resolve, reject) => {
-            const file_path = this.binPath(file_id);
+            const file_path = this.filePath(file_id);
             fs.stat(file_path, (error, stats) => {
                 if (error && error.code === FILE_DOESNT_EXIST && config) {
                     log(`[FileStore] getOffset: No file found at ${file_path} but db record exists`, config);
@@ -179,28 +186,52 @@ class FileStore extends DataStore {
         });
     }
 
-    binPath(file_id) {
+    /**
+     * Return file path
+     *
+     * @param  {string} file_id name of the file
+     * @return {string} file path
+     */
+    filePath(file_id) {
         return `${this.directory}/${file_id}`;
     }
 
-    configPath(file_id) {
+    /**
+     * infoPath returns the path to the .info file storing the file's info.
+     *
+     * @param  {string} file_id name of the file
+     * @return {string} .info file path
+     */
+    infoPath(file_id) {
         return `${this.directory}/${file_id}.info`;
     }
 
-    getConfig(file_id) {
+    /**
+     * Return file info
+     *
+     * @param  {string} file_id name of the file
+     * @return {object} File object or null on failure or does not exist
+     */
+    getFileInfo(file_id) {
         try {
-            const infoFilename = this.configPath(file_id);
+            const infoFilename = this.infoPath(file_id);
             const data = fs.readFileSync(infoFilename);
             const file = JSON.parse(data);
             return file;
         }
         catch (e) {
+            log(`[FileStore] getInfo: failure reading info for file id ${file_id} `, e);
             return null;
         }
     }
 
-    writeConfig(file) {
-        const infoFilename = this.configPath(file.id);
+    /**
+     * writeInfo writes the file info to .info file. Overwrites.
+     *
+     * @param  {object} File object
+     */
+    writeFileInfo(file) {
+        const infoFilename = this.infoPath(file.id);
         const data = JSON.stringify(file);
         writeFileAtomic.sync(infoFilename, data);
     }

--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -3,8 +3,7 @@
 const DataStore = require('./DataStore');
 const File = require('../models/File');
 const fs = require('fs');
-const Configstore = require('configstore');
-const pkg = require('../../package.json');
+const writeFileAtomic = require('write-file-atomic');
 const MASK = '0777';
 const IGNORED_MKDIR_ERROR = 'EEXIST';
 const FILE_DOESNT_EXIST = 'ENOENT';
@@ -27,7 +26,6 @@ class FileStore extends DataStore {
         this.directory = options.directory || options.path.replace(/^\//, '');
 
         this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length'];
-        this.configstore = new Configstore(`${pkg.name}-${pkg.version}`);
         this._checkOrCreateDirectory();
     }
 
@@ -69,14 +67,15 @@ class FileStore extends DataStore {
             }
 
             const file = new File(file_id, upload_length, upload_defer_length, upload_metadata);
+            const filepath = this.binPath(file_id);
 
-            return fs.open(`${this.directory}/${file.id}`, 'w', (err, fd) => {
+            return fs.open(filepath, 'w', (err, fd) => {
                 if (err) {
                     log('[FileStore] create: Error', err);
                     return reject(err);
                 }
 
-                this.configstore.set(file.id, file);
+                this.writeConfig(file);
 
                 return fs.close(fd, (exception) => {
                     if (exception) {
@@ -112,7 +111,7 @@ class FileStore extends DataStore {
      */
     write(req, file_id, offset) {
         return new Promise((resolve, reject) => {
-            const path = `${this.directory}/${file_id}`;
+            const path = this.binPath(file_id);
             const options = {
                 flags: 'r+',
                 start: offset,
@@ -135,7 +134,7 @@ class FileStore extends DataStore {
                 offset += new_offset;
                 log(`[FileStore] write: File is now ${offset} bytes`);
 
-                const config = this.configstore.get(file_id);
+                const config = this.getConfig(file_id);
                 if (config && parseInt(config.upload_length, 10) === offset) {
                     this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file: config });
                 }
@@ -151,9 +150,9 @@ class FileStore extends DataStore {
      * @return {object}           fs stats
      */
     getOffset(file_id) {
-        const config = this.configstore.get(file_id);
+        const config = this.getConfig(file_id);
         return new Promise((resolve, reject) => {
-            const file_path = `${this.directory}/${file_id}`;
+            const file_path = this.binPath(file_id);
             fs.stat(file_path, (error, stats) => {
                 if (error && error.code === FILE_DOESNT_EXIST && config) {
                     log(`[FileStore] getOffset: No file found at ${file_path} but db record exists`, config);
@@ -178,6 +177,32 @@ class FileStore extends DataStore {
                 return resolve(data);
             });
         });
+    }
+
+    binPath(file_id) {
+        return `${this.directory}/${file_id}`;
+    }
+
+    configPath(file_id) {
+        return `${this.directory}/${file_id}.info`;
+    }
+
+    getConfig(file_id) {
+        try {
+            const infoFilename = this.configPath(file_id);
+            const data = fs.readFileSync(infoFilename);
+            const file = JSON.parse(data);
+            return file;
+        }
+        catch (e) {
+            return null;
+        }
+    }
+
+    writeConfig(file) {
+        const infoFilename = this.configPath(file.id);
+        const data = JSON.stringify(file);
+        writeFileAtomic.sync(infoFilename, data);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@google-cloud/storage": "^5.3.0",
     "aws-sdk": "^2.761.0",
     "configstore": "^5.0.1",
-    "debug": "^4.2.0"
+    "debug": "^4.2.0",
+    "write-file-atomic": "^2.3.0"
   }
 }

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -63,7 +63,6 @@ describe('EndToEnd', () => {
                 }
 
                 // clear the config
-                server.datastore.configstore.clear();
                 listener.close();
                 return done();
             });

--- a/test/Test-FileStore.js
+++ b/test/Test-FileStore.js
@@ -50,8 +50,6 @@ describe('FileStore', () => {
                 return done(err);
             }
 
-            // clear the config
-            server.datastore.configstore.clear();
             return done();
         });
     });


### PR DESCRIPTION
configstore does a few things that are problematic:
- writes a file outside upload directory and with permissions so that group can't read/write
- file infos are never removed so it just grows larger

Moving to plain json file per upload in the upload directory enables you to clean the directory periodically of old files without disturbing in progress uploads. Same method that tusd uses.