### PR TITLE
Enable 0 byte files

### DIFF
--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -18,7 +18,7 @@ class RequestValidator {
 
     // The value MUST be a non-negative integer.
     static _invalidUploadLengthHeader(value) {
-        return isNaN(value) || parseInt(value, 10) < 1;
+        return isNaN(value) || parseInt(value, 10) < 0;
     }
 
     // The Upload-Defer-Length value MUST be 1.


### PR DESCRIPTION
fixes https://github.com/tus/tus-node-server/issues/98

---

According to @Acconut (https://github.com/tus/tus-js-client/issues/106#issuecomment-377223525), 0 bytes files should be handled directly in the `POST` (creation of a file) request.

In order to solve this, this pull request unblocks a file size of 0 bytes (`non-negative integer`).

The check if a file has 0 bytes will happen in every DataStores itself (within the `create` method).
I think updating current DataStores can be done in different pull requests.