### PR TITLE
Allow `Authorization` header. Closes #99

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,6 +8,7 @@ const REQUEST_METHODS = [
 ];
 
 const HEADERS = [
+    'Authorization',
     'Content-Type',
     'Location',
     'Tus-Extension',

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -67,6 +67,9 @@ class RequestValidator {
         return value !== 'application/offset+octet-stream';
     }
 
+    static _invalidAuthorizationHeader() {
+        return false;
+    }
 
     static capitalizeHeader(header_name) {
         return header_name.replace(/\b[a-z]/g, function() {

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -142,6 +142,13 @@ describe('RequestValidator', () => {
         });
     });
 
+    describe('_invalidAuthorizationHeader', () => {
+        it('always validate ', (done) => {
+            assert.equal(RequestValidator._invalidAuthorizationHeader(), false);
+            done();
+        });
+    });
+
     describe('_invalidContentTypeHeader', () => {
         it('should validate octet-stream', (done) => {
             assert.equal(RequestValidator._invalidContentTypeHeader('application/offset+octet-stream'), false);


### PR DESCRIPTION
This will allow requests with `Authorization` present on their headers.