### PR TITLE
Export Error Constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Server = require('./lib/Server');
 const DataStore = require('./lib/stores/DataStore');
 const FileStore = require('./lib/stores/FileStore');
 const GCSDataStore = require('./lib/stores/GCSDataStore');
+const ERRORS = require('./lib/constants').ERRORS;
 const EVENTS = require('./lib/constants').EVENTS;
 
 module.exports = {
@@ -11,5 +12,6 @@ module.exports = {
     DataStore,
     FileStore,
     GCSDataStore,
+    ERRORS,
     EVENTS,
 };


### PR DESCRIPTION
In advance of extracting individual datastore packages, export the error constants from the package to facilitate custom datastore creation more cleanly.