### PR TITLE
Do not reject unexpected content types during upload creation

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -148,6 +148,13 @@ class TusServer extends EventEmitter {
                 continue;
             }
 
+            // Content type is only checked for PATCH requests. For all other
+            // request methods it will be ignored and treated as no content type
+            // was set because some HTTP clients may enforce a default value for
+            // this header.
+            if (header_name.toLowerCase() === 'content-type' && req.method !== 'PATCH') {
+                continue;
+            } 
             if (RequestValidator.isInvalidHeader(header_name, req.headers[header_name])) {
                 log(`Invalid ${header_name} header: ${req.headers[header_name]}`);
                 invalid_headers.push(header_name);

--- a/test/Test-Server.js
+++ b/test/Test-Server.js
@@ -141,6 +141,20 @@ describe('Server', () => {
               .expect(412, 'Invalid upload-metadata\n', done);
         });
 
+        it('POST should ignore invalid Content-Type header', (done) => {
+            request(server.listen())
+              .post(server.datastore.path)
+              .set('Tus-Resumable', TUS_RESUMABLE)
+              .set('Upload-Length', 300)
+              .set('Upload-Metadata', 'foo aGVsbG8=, bar d29ynGQ=')
+              .set('Content-Type', 'application/false')
+              .expect(201, {}, done)
+              .end((err, res) => {
+                  res.headers.should.have.property('location');
+                  done();
+              });
+        });
+
         it('should 404 other requests', (done) => {
             request(server.listen())
               .get('/')


### PR DESCRIPTION
As a consequence for java's HttpUrlConnection implementation on some versions of Android, a default `Content-Type=application/x-www-form-urlencoded` header might be passed with no possibility to remove it for POST requests: tus-node-server responds with a 412 to any endpoint creation request.

Issue referenced in the tus-java-client repo: https://github.com/tus/tus-java-client/issues/10
with a fix implemented in the Go server impl: https://github.com/tus/tusd/commit/182a96e3e8c6ef287114b695bbceb6568e00ea0c

This is an attempt to apply the same fix on the tus node server implementation.

Please freely advise with any remarks.