### PR TITLE
allowing empty metadata values in RequestValidator

### DIFF
--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -34,13 +34,18 @@ class RequestValidator {
     // MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST
     // be Base64 encoded. All keys MUST be unique.
     static _invalidUploadMetadataHeader(value) {
+        if (value === "") {
+            return true;
+        }
+
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
-
         // Original code: check key/value pair. If value is empty, return true.
         // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
         for (let i = 0; i < keypairs.length; i++) {
-            if (keypairs[i].split(' ').length !== 2) {
+            if (keypairs[i].replace(/\s/g, '').length === 0) {
+                return true;
+            } else if (keypairs[i].split(' ').length !== 2) {
                 log('Empty Metadata: ${keypairs[i]}');
             }
         }

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -46,7 +46,8 @@ class RequestValidator {
             if (keypairs[i].replace(/\s/g, '').length === 0) {
                 log('Metadata: Empty');
                 return true;
-            } else if (keypairs[i].split(' ').length !== 2) {
+            } 
+            else if (keypairs[i].split(' ').length !== 2) {
                 log('Metadata: Empty value for key: ${keypairs[i]}');
             }
         }

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -34,10 +34,6 @@ class RequestValidator {
     // MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST
     // be Base64 encoded. All keys MUST be unique.
     static _invalidUploadMetadataHeader(value) {
-        if (value.indexOf(',') === -1) {
-            return true;
-        }
-
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
 

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -38,12 +38,13 @@ class RequestValidator {
                               .map((keypair) => keypair.trim());
 
         // Original code: check key/value pair. If value is empty, return true.
-        // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
-        for (let i = 0; i < keypairs.length; i++) {
-            if (keypairs[i].split(' ').length !== 2) {
-                log('Empty Metadata: ${keypairs[i]}');
-            }
-        }
+        return keypairs.some((keypair) => keypair.split(' ').length !== 2);
+        
+        // for (let i = 0; i < keypairs.length; i++) {
+        //    if (keypairs[i].split(' ').length !== 2) {
+        //        log('Empty Metadata: ${keypairs[i]}');
+        //    }
+        // }
 
         return false;
     }

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -6,6 +6,8 @@
  * @author Ben Stahl <bhstahl@gmail.com>
  */
 
+const debug = require('debug');
+const log = debug('tus-node-server');
 
 const CONSTANTS = require('../constants');
 
@@ -35,7 +37,14 @@ class RequestValidator {
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
 
-        return keypairs.some((keypair) => keypair.split(' ').length !== 2);
+        //return keypairs.some((keypair) => keypair.split(' ').length !== 2);
+        for(var i = 0; i < keypairs.length; i++) {
+            if(keypairs[i].split(' ').length != 2) {
+                log("Empty Metadata" + keypairs[i]);
+            }
+        }
+
+        return false;
     }
 
     static _invalidXRequestedWithHeader() {

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -6,8 +6,8 @@
  * @author Ben Stahl <bhstahl@gmail.com>
  */
 
-const debug = require('debug');
-const log = debug('tus-node-server');
+// const debug = require('debug');
+// const log = debug('tus-node-server');
 
 const CONSTANTS = require('../constants');
 
@@ -39,14 +39,6 @@ class RequestValidator {
 
         // Original code: check key/value pair. If value is empty, return true.
         return keypairs.some((keypair) => keypair.split(' ').length !== 2);
-        
-        // for (let i = 0; i < keypairs.length; i++) {
-        //    if (keypairs[i].split(' ').length !== 2) {
-        //        log('Empty Metadata: ${keypairs[i]}');
-        //    }
-        // }
-
-        return false;
     }
 
     static _invalidXRequestedWithHeader() {

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -6,8 +6,8 @@
  * @author Ben Stahl <bhstahl@gmail.com>
  */
 
-// const debug = require('debug');
-// const log = debug('tus-node-server');
+const debug = require('debug');
+const log = debug('tus-node-server');
 
 const CONSTANTS = require('../constants');
 
@@ -38,7 +38,14 @@ class RequestValidator {
                               .map((keypair) => keypair.trim());
 
         // Original code: check key/value pair. If value is empty, return true.
-        return keypairs.some((keypair) => keypair.split(' ').length !== 2);
+        // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
+        for (let i = 0; i < keypairs.length; i++) {
+            if (keypairs[i].split(' ').length !== 2) {
+                log('Empty Metadata: ${keypairs[i]}');
+            }
+        }
+
+        return false;
     }
 
     static _invalidXRequestedWithHeader() {

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -34,10 +34,10 @@ class RequestValidator {
     // MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST
     // be Base64 encoded. All keys MUST be unique.
     static _invalidUploadMetadataHeader(value) {
-        if (value.indexOf(',') > -1) {
+        if (value.indexOf(',') === -1) {
             return true;
         }
-        
+
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
 

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -46,7 +46,7 @@ class RequestValidator {
             if (keypairs[i].replace(/\s/g, '').length === 0) {
                 log('Metadata: Empty');
                 return true;
-            } 
+            }
             else if (keypairs[i].split(' ').length !== 2) {
                 log('Metadata: Empty value for key: ${keypairs[i]}');
             }

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -34,8 +34,10 @@ class RequestValidator {
     // MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST
     // be Base64 encoded. All keys MUST be unique.
     static _invalidUploadMetadataHeader(value) {
-        if (value.indexOf(',') > -1) return true;
-
+        if (value.indexOf(',') > -1) {
+            return true;
+        }
+        
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
 

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -39,7 +39,7 @@ class RequestValidator {
 
         // Original code: check key/value pair. If value is empty, return true.
         // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
-        for (const i = 0; i < keypairs.length; i++) {
+        for (let i = 0; i < keypairs.length; i++) {
             if (keypairs[i].split(' ').length !== 2) {
                 log('Empty Metadata: ${keypairs[i]}');
             }

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -34,6 +34,8 @@ class RequestValidator {
     // MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST
     // be Base64 encoded. All keys MUST be unique.
     static _invalidUploadMetadataHeader(value) {
+        if (value.indexOf(',') > -1) return true;
+
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
 

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -34,7 +34,7 @@ class RequestValidator {
     // MUST NOT be empty. The key SHOULD be ASCII encoded and the value MUST
     // be Base64 encoded. All keys MUST be unique.
     static _invalidUploadMetadataHeader(value) {
-        if (value === "") {
+        if (value === '') {
             return true;
         }
 
@@ -43,10 +43,13 @@ class RequestValidator {
         // Original code: check key/value pair. If value is empty, return true.
         // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
         for (let i = 0; i < keypairs.length; i++) {
-            if (keypairs[i].replace(/\s/g, '').length === 0) {
+            if (keypairs[i].replace(/\s/g, '').length === 0) 
+            {
+                log('Metadata: Empty');
                 return true;
-            } else if (keypairs[i].split(' ').length !== 2) {
-                log('Empty Metadata: ${keypairs[i]}');
+            } else if (keypairs[i].split(' ').length !== 2)
+            {
+                log('Metadata: Empty value for key: ${keypairs[i]}');
             }
         }
 

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -43,12 +43,10 @@ class RequestValidator {
         // Original code: check key/value pair. If value is empty, return true.
         // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
         for (let i = 0; i < keypairs.length; i++) {
-            if (keypairs[i].replace(/\s/g, '').length === 0) 
-            {
+            if (keypairs[i].replace(/\s/g, '').length === 0) {
                 log('Metadata: Empty');
                 return true;
-            } else if (keypairs[i].split(' ').length !== 2)
-            {
+            } else if (keypairs[i].split(' ').length !== 2) {
                 log('Metadata: Empty value for key: ${keypairs[i]}');
             }
         }

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -37,10 +37,11 @@ class RequestValidator {
         const keypairs = value.split(',')
                               .map((keypair) => keypair.trim());
 
-        //return keypairs.some((keypair) => keypair.split(' ').length !== 2);
-        for(var i = 0; i < keypairs.length; i++) {
-            if(keypairs[i].split(' ').length != 2) {
-                log("Empty Metadata" + keypairs[i]);
+        // Original code: check key/value pair. If value is empty, return true.
+        // return keypairs.some((keypair) => keypair.split(' ').length !== 2);
+        for (const i = 0; i < keypairs.length; i++) {
+            if (keypairs[i].split(' ').length !== 2) {
+                log('Empty Metadata: ${keypairs[i]}');
             }
         }
 

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -80,9 +80,9 @@ describe('RequestValidator', () => {
         });
 
         it('should fail on non comma separated list', (done) => {
-            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), false);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), false);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), false);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), true);
             done();
         });
     });

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -81,7 +81,7 @@ describe('RequestValidator', () => {
 
         it('should fail on non comma separated list', (done) => {
             assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), true);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), false);
             assert.equal(RequestValidator._invalidUploadMetadataHeader(''), true);
             done();
         });

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -82,7 +82,8 @@ describe('RequestValidator', () => {
         it('should fail on non comma separated list', (done) => {
             assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), false);
             assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), false);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), false);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('  \t\n'), true);
             done();
         });
     });

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -82,7 +82,7 @@ describe('RequestValidator', () => {
         it('should fail on non comma separated list', (done) => {
             assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), false);
             assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), false);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), false);
             done();
         });
     });

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -80,9 +80,9 @@ describe('RequestValidator', () => {
         });
 
         it('should fail on non comma separated list', (done) => {
-            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), true);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), true);
-            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), false);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), false);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader(''), false);
             done();
         });
     });

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -80,7 +80,7 @@ describe('RequestValidator', () => {
         });
 
         it('should fail on non comma separated list', (done) => {
-            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), true);
+            assert.equal(RequestValidator._invalidUploadMetadataHeader('hello'), false);
             assert.equal(RequestValidator._invalidUploadMetadataHeader('hello world, tusrules'), false);
             assert.equal(RequestValidator._invalidUploadMetadataHeader(''), true);
             done();


### PR DESCRIPTION
this change relates to issue #117; whereby if metadata value is empty, tuss node server will return 412  error.
As suggested by @Acconut, I modified RequestValidator.js to allow empty metadata value; however I log a message showing "Empty Metadata: " + key.