### PR TITLE
fix relative location url

### DIFF
--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -16,7 +16,7 @@ class PostHandler extends BaseHandler {
     send(req, res) {
         return this.store.create(req)
             .then((File) => {
-                const url = this.store.relativeLocation ? `${File.id}` : `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
+                const url = this.store.relativeLocation ? `${req.baseUrl || ''}${this.store.path}/${File.id}` : `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
 
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
                 return super.send(res, 201, { Location: url });

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -256,7 +256,7 @@ describe('EndToEnd', () => {
                     // the location header is not absolute
                     assert.equal(res.headers.location.indexOf("//") === -1, true);
                     // and contains the store path
-                    assert.equal(res.headers.location.indexOf(STORE_PATH) > -1, false);
+                    assert.equal(res.headers.location.indexOf(STORE_PATH) > -1, true);
                     done();
                 });
             });

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -253,7 +253,9 @@ describe('EndToEnd', () => {
                 .end((err, res) => {
                     assert.equal('location' in res.headers, true);
                     assert.equal(res.headers['tus-resumable'], TUS_RESUMABLE);
-                    // the location header is relative to the store path
+                    // the location header is not absolute
+                    assert.equal(res.headers.location.indexOf("//") === -1, true);
+                    // and contains the store path
                     assert.equal(res.headers.location.indexOf(STORE_PATH) > -1, false);
                     done();
                 });


### PR DESCRIPTION
hey, thanks for #128 

with `relativeLocation: true` the returned location is only `{uuid}`
it should return the same url just without scheme + host

with patch applied:
`relativeLocation: false` => `//localhost/tus/files/{uuid}`
`relativeLocation: true` => `/tus/files/{uuid}`
