### PR TITLE
Take chunk/part to upload to S3 from req.body or req

### DIFF
--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -257,19 +257,19 @@ class S3Store extends DataStore {
     /**
      * Uploads a part/chunk to S3 from a temporary part file.
      *
-     * @param  {Object}          metadata            upload metadata
-     * @param  {Stream}          read_stream         incoming request read stream
-     * @param  {Number}          current_part_number number of the current part/chunk
-     * @return {Promise<String>}                     which resolves with the parts' etag
+     * @param  {Object}               metadata            upload metadata
+     * @param  {Buffer|Stream|String} data                upload part/chunk data
+     * @param  {Number}               current_part_number number of the current part/chunk
+     * @return {Promise<String>}                          which resolves with the parts' etag
      */
-    _uploadPart(metadata, read_stream, current_part_number) {
+    _uploadPart(metadata, data, current_part_number) {
         return this.client
             .uploadPart({
                 Bucket: this.bucket_name,
                 Key: metadata.file.id,
                 UploadId: metadata.upload_id,
                 PartNumber: current_part_number,
-                Body: read_stream,
+                Body: data
             })
             .promise()
             .then((data) => {
@@ -284,17 +284,20 @@ class S3Store extends DataStore {
 
     /**
      * Processes the following steps:
-     * - uploads a part (stream) to s3
+     * - uploads a part to s3
      * - finishes the upload in case offset === length
      *
      * @param {Object}                metadata            upload metadata
      * @param {http<IncomingMessage>} req                 incoming request
      * @param {Number}                current_part_number number of the current part/chunk
-     * @return {Promise<Number>}                         which resolves with the current offset
+     * @return {Promise<Number>}                          which resolves with the current offset
      * @memberof S3Store
      */
     _processUpload(metadata, req, current_part_number) {
-        return this._uploadPart(metadata, req, current_part_number)
+        const data = req.body instanceof Buffer || typeof req.body === 'string' ||
+            (ArrayBuffer.isView(req.body) && !(req.body instanceof DataView)) ?
+            req.body : req;
+        return this._uploadPart(metadata, data, current_part_number)
             .then(() => this.getOffset(metadata.file.id, true))
             .then((current_offset) => {
                 if (parseInt(metadata.file.upload_length, 10) === current_offset.size) {


### PR DESCRIPTION
`S3Store` expects the incoming request (`req`) to be a readable stream and forwards it to AWS SDK's `uploadPart` function. In case stream is already consumed and not readable anymore upload to S3 fails. In my use case, I check uploaded content in Express middleware and parse uploaded file data to `req.body` with `bodyParser` before request is forwarded to `tus-node-server`. In order to work I extended `_processUpload` to handle chunk/part data in `req.body` and fall back to `req` (stream) if not set.