### PR TITLE
FIX: PATCH receives 404 with relativeLocation set to true

### DIFF
--- a/lib/handlers/BaseHandler.js
+++ b/lib/handlers/BaseHandler.js
@@ -41,7 +41,8 @@ class BaseHandler extends EventEmitter {
      * @return {bool|string}
      */
     getFileIdFromRequest(req) {
-        const re = new RegExp(`${req.baseUrl || ''}${this.store.path}\\/(\\S+)\\/?`); // eslint-disable-line prefer-template
+        const re = this.store.relativeLocation ? new RegExp(`${req.baseUrl || ''}\\/(\\S+)\\/?`) : new RegExp(`${req.baseUrl || ''}${this.store.path}\\/(\\S+)\\/?`); // eslint-disable-line prefer-template
+
         const match = (req.originalUrl || req.url).match(re);
         if (!match) {
             return false;

--- a/test/Test-BaseHandler.js
+++ b/test/Test-BaseHandler.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 const assert = require('assert');
 const httpMocks = require('node-mocks-http');
 
@@ -51,6 +53,40 @@ describe('BaseHandler', () => {
         done();
     });
 
+    describe('getFileIdFromRequest()', () => {
+      const filePath = '/files'
+      const filename = 'Abklz1xxRcmbf7fqUa6rHg.mp4'
+
+      it('relativeLocation = false. should return fileId', (done) => {
+          const store = new DataStore({ path: filePath });
+          const handler = new BaseHandler(store);
+
+          const req = httpMocks.createRequest({
+            method: 'PATCH',
+            originalUrl: path.join(filePath, filename)
+          });
+
+          const fileId = handler.getFileIdFromRequest(req);
+
+          assert.equal(fileId, filename);
+          done();
+      })
+
+      it('relativeLocation = true. should return fileId', (done) => {
+          const store = new DataStore({ path: filePath, relativeLocation: true });
+          const handler = new BaseHandler(store);
+
+          const req = httpMocks.createRequest({
+            method: 'PATCH',
+            originalUrl: path.join('/', filename)
+          });
+
+          const fileId = handler.getFileIdFromRequest(req);
+
+          assert.equal(fileId, filename);
+          done();
+      })
+    })
 
     it('send() should write the body', (done) => {
         const body = 'Hello tus!'


### PR DESCRIPTION
Issue: PATCH requests receives `404 -  The file for this url was not found` error.

The `getFileIdFromRequest` method doesn't consider `relativeLocation` value, and always tries to compare the request URL with file's full path.