### PR TITLE
resumable uploads with GCS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 tus is a new open protocol for resumable uploads built on HTTP. This is the [tus protocol 1.0.0](http://tus.io/protocols/resumable-upload.html) node.js server implementation.
 
-> :warning: **Attention:** We currently lack the resources to properly maintain tus-node-server. This has the unfortunate consequence that this project is in rather bad condition (out-dated dependencies, no tests for the S3 storage, no resumable uploads for the GCS storage etc). If you want to help us with tus-node-server, we are more than happy to assist you and welcome new contributors. In the meantime, we can recommend [tusd](https://github.com/tus/tusd) as a reliable and production-tested tus server. Of course, you can use tus-node-server if it serves your purpose.
+> :warning: **Attention:** We currently lack the resources to properly maintain tus-node-server. This has the unfortunate consequence that this project is in rather bad condition (out-dated dependencies, no tests for the S3 storage etc). If you want to help us with tus-node-server, we are more than happy to assist you and welcome new contributors. In the meantime, we can recommend [tusd](https://github.com/tus/tusd) as a reliable and production-tested tus server. Of course, you can use tus-node-server if it serves your purpose.
 
 ## Installation
 

--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -131,7 +131,7 @@ class GCSDataStore extends DataStore {
                 return new Promise((resolve, reject) => {
                     const file = this.bucket.file(file_id);
 
-                    const destination = data.size === 0 ? file : this.bucket.file(file_id + "_patch");
+                    const destination = data.size === 0 ? file : this.bucket.file(`${file_id}_patch`);
 
                     const options = {
                         offset,
@@ -155,19 +155,19 @@ class GCSDataStore extends DataStore {
                         new_offset += buffer.length;
                     });
 
-                    write_stream.on('finish', async () => {
+                    write_stream.on('finish', async() => {
                         log(`${new_offset} bytes written`);
 
                         try {
-                            if (file != destination) {
-                                await this.bucket.combine([file, destination], file)
+                            if (file !== destination) {
+                                await this.bucket.combine([file, destination], file);
                                 await Promise.all([file.setMetadata(options.metadata), destination.delete({ ignoreNotFound: true })]);
                             }
-    
+
                             if (data.upload_length === new_offset) {
                                 this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file });
                             }
-    
+
                             resolve(new_offset);
                         }
                         catch (e) {
@@ -176,11 +176,13 @@ class GCSDataStore extends DataStore {
                         }
                     });
 
-                    write_stream.on('error', async (e) => {
+                    write_stream.on('error', async(e) => {
                         log(e);
                         try {
                             await destination.delete({ ignoreNotFound: true });
-                        } catch (e) {}
+                        } catch {
+                            // ignore error
+                        }
 
                         reject(ERRORS.FILE_WRITE_ERROR);
                     });

--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -131,6 +131,8 @@ class GCSDataStore extends DataStore {
                 return new Promise((resolve, reject) => {
                     const file = this.bucket.file(file_id);
 
+                    const destination = data.size === 0 ? file : this.bucket.file(file_id + "_patch");
+
                     const options = {
                         offset,
                         metadata: {
@@ -143,28 +145,43 @@ class GCSDataStore extends DataStore {
                         },
                     };
 
-                    const write_stream = file.createWriteStream(options);
+                    const write_stream = destination.createWriteStream(options);
                     if (!write_stream) {
                         return reject(ERRORS.FILE_WRITE_ERROR);
                     }
 
-                    let new_offset = 0;
+                    let new_offset = data.size;
                     req.on('data', (buffer) => {
                         new_offset += buffer.length;
                     });
 
-                    write_stream.on('finish', () => {
+                    write_stream.on('finish', async () => {
                         log(`${new_offset} bytes written`);
 
-                        if (data.upload_length === new_offset) {
-                            this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file });
+                        try {
+                            if (file != destination) {
+                                await this.bucket.combine([file, destination], file)
+                                await Promise.all([file.setMetadata(options.metadata), destination.delete({ ignoreNotFound: true })]);
+                            }
+    
+                            if (data.upload_length === new_offset) {
+                                this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file });
+                            }
+    
+                            resolve(new_offset);
                         }
-
-                        resolve(new_offset);
+                        catch (e) {
+                            log(e);
+                            reject(ERRORS.FILE_WRITE_ERROR);
+                        }
                     });
 
-                    write_stream.on('error', (e) => {
+                    write_stream.on('error', async (e) => {
                         log(e);
+                        try {
+                            await destination.delete({ ignoreNotFound: true });
+                        } catch (e) {}
+
                         reject(ERRORS.FILE_WRITE_ERROR);
                     });
 

--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -180,7 +180,8 @@ class GCSDataStore extends DataStore {
                         log(e);
                         try {
                             await destination.delete({ ignoreNotFound: true });
-                        } finally {
+                        }
+                        finally {
                             reject(ERRORS.FILE_WRITE_ERROR);
                         }
                     });

--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -180,11 +180,9 @@ class GCSDataStore extends DataStore {
                         log(e);
                         try {
                             await destination.delete({ ignoreNotFound: true });
-                        } catch {
-                            // ignore error
+                        } finally {
+                            reject(ERRORS.FILE_WRITE_ERROR);
                         }
-
-                        reject(ERRORS.FILE_WRITE_ERROR);
                     });
 
                     return req.pipe(write_stream);


### PR DESCRIPTION
My solution is to write to temporary file on subsequent writes and combine with original file. Temporary file is discarded immediately after write.  

I added test for this behavior and improved some other test. Many tests did not remove files after.

Resolves https://github.com/tus/tus-node-server/issues/37