### PR TITLE
implementation of creation-with-upload extention

### DIFF
--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseHandler = require('./BaseHandler');
+const RequestValidator = require('../validators/RequestValidator');
 const ERRORS = require('../constants').ERRORS;
 const EVENT_ENDPOINT_CREATED = require('../constants').EVENT_ENDPOINT_CREATED;
 const debug = require('debug');
@@ -15,11 +16,20 @@ class PostHandler extends BaseHandler {
      */
     send(req, res) {
         return this.store.create(req)
-            .then((File) => {
+            .then(async(File) => {
                 const url = this.store.relativeLocation ? `${req.baseUrl || ''}${this.store.path}/${File.id}` : `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
 
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
-                return super.send(res, 201, { Location: url });
+
+                const optional_headers = {};
+
+                // The request MIGHT include a Content-Type header when using creation-with-upload extension
+                if (!RequestValidator.isInvalidHeader('content-type', req.headers['content-type'])) {
+                    const new_offset = await this.store.write(req, File.id, 0);
+                    optional_headers['Upload-Offset'] = new_offset;
+                }
+
+                return super.send(res, 201, { Location: url, ...optional_headers });
             })
             .catch((error) => {
                 log('[PostHandler]', error);

--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -26,7 +26,7 @@ class FileStore extends DataStore {
 
         this.directory = options.directory || options.path.replace(/^\//, '');
 
-        this.extensions = ['creation', 'creation-defer-length'];
+        this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length'];
         this.configstore = new Configstore(`${pkg.name}-${pkg.version}`);
         this._checkOrCreateDirectory();
     }

--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -23,7 +23,7 @@ const log = debug('tus-node-server:stores:gcsstore');
 class GCSDataStore extends DataStore {
     constructor(options) {
         super(options);
-        this.extensions = ['creation', 'creation-defer-length'];
+        this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length'];
 
         if (!options.bucket) {
             throw new Error('GCSDataStore must have a bucket');

--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -59,7 +59,7 @@ class S3Store extends DataStore {
     constructor(options) {
         super(options);
 
-        this.extensions = ['creation', 'creation-defer-length'];
+        this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length'];
 
         assert.ok(options.accessKeyId, '[S3Store] `accessKeyId` must be set');
         assert.ok(options.secretAccessKey, '[S3Store] `secretAccessKey` must be set');

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -126,6 +126,30 @@ describe('EndToEnd', () => {
                     done();
                 });
             });
+
+            it('should create a file and upload content', (done) => {
+                const read_stream = fs.createReadStream(TEST_FILE_PATH);
+                const write_stream = agent.post(STORE_PATH)
+                .set('Tus-Resumable', TUS_RESUMABLE)
+                .set('Upload-Length', TEST_FILE_SIZE)
+                .set('Content-Type', 'application/offset+octet-stream');
+
+                write_stream.on('response', (res) => {
+                    assert.equal(res.statusCode, 201);
+                    assert.equal(res.header['tus-resumable'], TUS_RESUMABLE);
+                    assert.equal(res.header['upload-offset'], `${TEST_FILE_SIZE}`);
+                    done();
+                });
+
+                // Using .pipe() broke when upgrading to Superagent 3.0+,
+                // so now we use data events to read the file to the agent.
+                read_stream.on('data', (chunk) => {
+                    write_stream.write(chunk);
+                });
+                read_stream.on("end", () => {
+                    write_stream.end(() => {});
+                });
+            });
         });
 
         describe('HEAD', () => {

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -378,6 +378,30 @@ describe('EndToEnd', () => {
                     done();
                 });
             });
+
+            it('should create a file and upload content', (done) => {
+                const read_stream = fs.createReadStream(TEST_FILE_PATH);
+                const write_stream = agent.post(STORE_PATH)
+                .set('Tus-Resumable', TUS_RESUMABLE)
+                .set('Upload-Length', TEST_FILE_SIZE)
+                .set('Content-Type', 'application/offset+octet-stream');
+
+                write_stream.on('response', (res) => {
+                    assert.equal(res.statusCode, 201);
+                    assert.equal(res.header['tus-resumable'], TUS_RESUMABLE);
+                    assert.equal(res.header['upload-offset'], `${TEST_FILE_SIZE}`);
+                    done();
+                });
+
+                // Using .pipe() broke when upgrading to Superagent 3.0+,
+                // so now we use data events to read the file to the agent.
+                read_stream.on('data', (chunk) => {
+                    write_stream.write(chunk);
+                });
+                read_stream.on("end", () => {
+                    write_stream.end(() => {});
+                });
+            })
         });
 
         describe('HEAD', () => {


### PR DESCRIPTION
When `Content-Type: application/offset+octet-stream` header is present also start upload. I did not want to start file upload when there is no `Content-Type` header as is implemented in goloang, beause that would make additional requests to store (GCS, S3, ...) also in requests when there is no data to upload.