### PR TITLE
Add metadata parsing and stringification functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const DataStore = require('./lib/stores/DataStore');
 const FileStore = require('./lib/stores/FileStore');
 const GCSDataStore = require('./lib/stores/GCSDataStore');
 const S3Store = require('./lib/stores/S3Store');
+const Metadata = require('./lib/models/Metadata');
 const ERRORS = require('./lib/constants').ERRORS;
 const EVENTS = require('./lib/constants').EVENTS;
 
@@ -14,6 +15,7 @@ module.exports = {
     FileStore,
     GCSDataStore,
     S3Store,
+    Metadata,
     ERRORS,
     EVENTS,
 };

--- a/lib/models/Metadata.js
+++ b/lib/models/Metadata.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/**
+ * @fileOverview
+ * Utility function for metdata manipulation
+ *
+ * @author Mitja Puzigaća <mitjap@gmail.com>
+ */
+
+const ASCII_SPACE = ' '.codePointAt(0);
+const ASCII_COMMA = ','.codePointAt(0);
+
+const BASE64_REGEX = /^[a-zA-Z0-9+/]*[=]{0,2}$/;
+
+function validateKey(key) {
+    if (key.length === 0) {
+        return false;
+    }
+
+    for (let i = 0; i < key.length; ++i) {
+        const charCodePoint = key.codePointAt(i);
+
+        if (charCodePoint > 127 ||
+            charCodePoint === ASCII_SPACE ||
+            charCodePoint === ASCII_COMMA) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function validateValue(value) {
+    if (value.length % 4 !== 0) {
+        return false;
+    }
+
+    return BASE64_REGEX.test(value);
+}
+
+function parse(str) {
+    const meta = {};
+
+    for (const pair of str.split(',')) {
+        const tokens = pair.split(' ');
+        const [key, value] = tokens;
+
+        if ((
+            (tokens.length === 1 && validateKey(key)) ||
+            (tokens.length === 2 && validateKey(key) && validateValue(value))
+        ) && (!(key in meta))) {
+            const decodedValue = value ? Buffer.from(value, 'base64').toString('utf8') : undefined;
+            meta[key] = decodedValue;
+        }
+        else {
+            throw new Error('Metadata string is not valid');
+        }
+    }
+
+    return meta;
+}
+
+function stringify(obj) {
+    return Object.entries(obj).map(([key, value]) => {
+        if (value === undefined) {
+            return key;
+        }
+
+        const encodedValue = Buffer.from(value, 'utf8').toString('base64');
+        return `${key} ${encodedValue}`;
+    }).join(',');
+}
+
+module.exports = {
+    parse,
+    stringify,
+};

--- a/test/Test-Metadata.js
+++ b/test/Test-Metadata.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('assert');
+const Metadata = require('../lib/models/Metadata');
+
+describe('Metadata', () => {
+
+    it('parse valid metadata string', () => {
+        const str = 'file/name dGVzdC5tcDQ=,size OTYwMjQ0,type! dmlkZW8vbXA0,video,withWhitespace '
+        const obj = {
+            'file/name': 'test.mp4',
+            size: '960244',
+            'type!': 'video/mp4',
+            video: undefined,
+            withWhitespace: undefined 
+        };
+
+        const decoded = Metadata.parse(str);
+        assert.deepStrictEqual(decoded, obj);
+    });
+
+    it('check length of metadata string', () => {
+        const obj = {
+            filename: 'test.mp4',
+            size: '960244',
+            type: 'video/mp4',
+            video: undefined,
+            withWhitespace: undefined 
+        };
+
+        const encoded = Metadata.stringify(obj);
+        assert.strictEqual(encoded.split(",").length, Object.entries(obj).length);
+    });
+
+    it('verify metadata stringification', () => {
+        assert.strictEqual(Metadata.stringify({ filename: 'test.mp4' }), 'filename dGVzdC5tcDQ=');
+        assert.strictEqual(Metadata.stringify({ size: '960244' }), 'size OTYwMjQ0');
+        assert.strictEqual(Metadata.stringify({ type: 'video/mp4' }), 'type dmlkZW8vbXA0');
+
+        // multiple valid options
+        assert.notStrictEqual(['video', 'video '].indexOf(Metadata.stringify({ video: undefined })), -1);
+        assert.notStrictEqual(['withWhitespace', 'withWhitespace '].indexOf(Metadata.stringify({ withWhitespace: undefined })), -1);
+    });
+
+    it('verify metadata parsing', () => {
+        assert.deepStrictEqual(Metadata.parse('filename dGVzdC5tcDQ='), { filename: 'test.mp4' });
+        assert.deepStrictEqual(Metadata.parse('size OTYwMjQ0'), { size: '960244' });
+        assert.deepStrictEqual(Metadata.parse('type dmlkZW8vbXA0'), { type: 'video/mp4' });
+
+        assert.deepStrictEqual(Metadata.parse('video'), { video: undefined });
+        assert.deepStrictEqual(Metadata.parse('video '), { video: undefined });
+        assert.deepStrictEqual(Metadata.parse('withWhitespace'), { withWhitespace: undefined });
+        assert.deepStrictEqual(Metadata.parse('withWhitespace '), { withWhitespace: undefined });
+    });
+
+    it('cyclic test', () => {
+        const obj = {
+            filename: 'world_domination_plan.pdf',
+            is_confidential: undefined,
+        };
+
+        // object -> string -> object
+        assert.deepStrictEqual(Metadata.parse(Metadata.stringify(obj)), obj);
+    })
+
+    describe('verify invalid metadata string', () => {
+
+        it ('duplicate keys', () => {
+            assert.throws(() => { Metadata.parse("filename dGVzdC5tcDQ=, filename cGFja2FnZS5qc29u"); });
+            assert.throws(() => { Metadata.parse("video ,video dHJ1ZQ=="); });
+            assert.throws(() => { Metadata.parse("size,size "); });
+        });
+
+        it ('invalid key', () => {
+            assert.throws(() => { Metadata.parse("🦁 ZW1vamk="); });
+            assert.throws(() => { Metadata.parse("€¢ß"); });
+            assert.throws(() => { Metadata.parse("test, te st "); });
+            assert.throws(() => { Metadata.parse("test,,test"); });
+        });
+
+        it ('invalid base64 value', () => {
+            assert.throws(() => { Metadata.parse("key ZW1vamk"); }); // value is not a multiple of 4 characters
+            assert.throws(() => { Metadata.parse("key invalid-base64=="); });
+            assert.throws(() => { Metadata.parse("key =ZW1vamk"); }); // padding can not be at the beginning
+            assert.throws(() => { Metadata.parse("key  "); }); // only single whitespace is allowed
+        });
+    })
+});


### PR DESCRIPTION
Metadata is part of a standard and stores might or might not use it. I think that parsing and stringification should be implemented as part of this library (and properly test) even though it is not directly used as metadata is usually just stored in it's encoded form.

I use naming convention from `JSON.parse` and `JSON.stringify`. `Metadata.encode` and `Metadata.decode` can also be used.