### PR TITLE
index.d.ts: fix http import to work without default exports set

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import * as fs from "fs";
-import http from "http";
+import * as http from "http";
 
 /**
  * arguments of constructor which in class extend DataStore


### PR DESCRIPTION
Without `allowSyntheticDefaultExports` set to `true` in `tsconfig.json`, `import http from "http"` will cause typechecking to fail.

AFAIK explicitly changing this to `import * as http from "http"` as with the `fs` import above it should be safe regardless of the synthetic default export setting.