### PR TITLE
index.d.ts: explicitly type Server.get callback parameter signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ export declare class Server extends EventEmitter {
     constructor();
     get datastore(): DataStore;
     set datastore(store: DataStore);
-    get(path: string, callback: (...args) => any): any;
+    get(path: string, callback: (...args: any[]) => any): any;
     handle(
         req: http.IncomingMessage,
         res: http.ServerResponse


### PR DESCRIPTION
Updates the type of the `Server.get` `callback` parameter to explicitly set its `...args` parameter as `any[]`.

Otherwise, with `noImplicitAny` set in tsconfig, tsc will complain about the implicit `any` type.