### PR TITLE
Sanitize file URLs

### DIFF
--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -17,7 +17,12 @@ class PostHandler extends BaseHandler {
     send(req, res) {
         return this.store.create(req)
             .then(async(File) => {
-                const url = this.store.relativeLocation ? `${req.baseUrl || ''}${this.store.path}/${File.id}` : `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;
+                const relativeLocation = (`${req.baseUrl || ''}${this.store.path.trim()}/${File.id}`)
+                    .replace(new RegExp('/{1,}', 'g'), '/');
+                /* eslint-disable-next-line */
+                const absoluteLocation = '//' + (`${req.headers.host}${req.baseUrl || ''}${this.store.path.trim()}/${File.id}`)
+                    .replace(new RegExp('/{1,}', 'g'), '/');
+                const url = this.store.relativeLocation ? relativeLocation : absoluteLocation;
 
                 this.emit(EVENT_ENDPOINT_CREATED, { url });
 


### PR DESCRIPTION
The current behaviour is creating a bad file url when the `path` is set to the root:
```js
    server.datastore = new tus.FileStore({
      path: '/'
    })
```
results in a URL of the form `http://localhost//12334456`

This sanitizes the constructed url when posting the download so that it results in a valid URL for the created file. Trimming was added as well.