### PR TITLE
Reject partial upload if concatenation extension is not supported

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -15,6 +15,7 @@ const HEADERS = [
     'Tus-Max-Size',
     'Tus-Resumable',
     'Tus-Version',
+    'Upload-Concat',
     'Upload-Defer-Length',
     'Upload-Length',
     'Upload-Metadata',

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -16,7 +16,7 @@ class PostHandler extends BaseHandler {
      */
     send(req, res) {
         if ('upload-concat' in req.headers && !this.store.hasExtension('concatentation')) {
-            return Promise.resolve(super.send(res, 400, {}, 'Concatenation extension is not supported'));
+            return Promise.resolve(super.send(res, 501, {}, 'Concatenation extension is not (yet) supported. Disable parallel uploads in the tus client. '));
         }
 
         return this.store.create(req)

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -15,6 +15,10 @@ class PostHandler extends BaseHandler {
      * @return {function}
      */
     send(req, res) {
+        if ('upload-concat' in req.headers && !this.store.hasExtension('concatentation')) {
+            return Promise.resolve(super.send(res, 400, {}, 'Concatenation extension is not supported'));
+        }
+
         return this.store.create(req)
             .then(async(File) => {
                 const url = this.store.relativeLocation ? `${req.baseUrl || ''}${this.store.path}/${File.id}` : `//${req.headers.host}${req.baseUrl || ''}${this.store.path}/${File.id}`;

--- a/lib/stores/DataStore.js
+++ b/lib/stores/DataStore.js
@@ -43,7 +43,7 @@ class DataStore extends EventEmitter {
     }
 
     hasExtension(extension) {
-        return this._extensions.indexOf(extension) !== -1;
+        return this._extensions && this._extensions.indexOf(extension) !== -1;
     }
 
     /**

--- a/lib/validators/RequestValidator.js
+++ b/lib/validators/RequestValidator.js
@@ -72,6 +72,13 @@ class RequestValidator {
         return false;
     }
 
+    static _invalidUploadConcatHeader(value) {
+        const valid_partial = value === 'partial';
+        const valid_final = value.startsWith('final;');
+
+        return !valid_partial && !valid_final;
+    }
+
     static capitalizeHeader(header_name) {
         return header_name.replace(/\b[a-z]/g, function() {
             return arguments[0].toUpperCase();

--- a/test/Test-PostHandler.js
+++ b/test/Test-PostHandler.js
@@ -35,10 +35,10 @@ describe('PostHandler', () => {
             .catch(done);
         });
 
-        it('must 400 if the \'concatenation\' extension is not supported', (done) => {
+        it('must 501 if the \'concatenation\' extension is not supported', (done) => {
             req.headers = { 'upload-concat': 'partial' };
             handler.send(req, res).then(() => {
-                assert.equal(res.statusCode, 400);
+                assert.equal(res.statusCode, 501);
                 return done();
             })
             .catch(done);

--- a/test/Test-PostHandler.js
+++ b/test/Test-PostHandler.js
@@ -35,6 +35,15 @@ describe('PostHandler', () => {
             .catch(done);
         });
 
+        it('must 400 if the \'concatenation\' extension is not supported', (done) => {
+            req.headers = { 'upload-concat': 'partial' };
+            handler.send(req, res).then(() => {
+                assert.equal(res.statusCode, 400);
+                return done();
+            })
+            .catch(done);
+        });
+
         it('must acknowledge successful POST requests with the 201', (done) => {
             req.headers = { 'upload-length': 1000, host: 'localhost:3000' };
 

--- a/test/Test-RequestValidator.js
+++ b/test/Test-RequestValidator.js
@@ -93,6 +93,21 @@ describe('RequestValidator', () => {
         });
     });
 
+    describe('_invalidUploadConcatHeader', () => {
+        it('should validate partial and final', (done) => {
+            assert.equal(RequestValidator._invalidUploadConcatHeader('partial'), false);
+            assert.equal(RequestValidator._invalidUploadConcatHeader('final;/files/a /files/b'), false);
+            done();
+        });
+
+        it('should invalidate everything else', (done) => {
+            assert.equal(RequestValidator._invalidUploadConcatHeader(''), true);
+            assert.equal(RequestValidator._invalidUploadConcatHeader('PARTIAL'), true);
+            assert.equal(RequestValidator._invalidUploadConcatHeader('invalid-value'), true);
+            done();
+        });
+    });
+
     describe('_invalidXRequestedWithHeader', () => {
         it('always validate ', (done) => {
             assert.equal(RequestValidator._invalidXRequestedWithHeader(), false);


### PR DESCRIPTION
Server returns error 400 and obvious error message if client wants to use concatenation extension when it is not supported.