### PR TITLE
GitHub Actions: allow PRs from forks to run with secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   CI:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ name: Node.js CI
 on:
   push:
     branches: [ master ]
+  pull_request:
+    types: [ opened, synchronize, reopened ]
   pull_request_target:
     types: [ opened, synchronize, reopened ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,5 @@ test/output
 
 *.sublime-workspace
 
-# Keyfile will be decrypted from keyfile.json.enc by travis
-# https://docs.travis-ci.com/user/encrypting-files/
+# Keyfile will be decrypted from keyfile.json.enc by GitHub Actions
 keyfile.json


### PR DESCRIPTION
Can't run tests from contributors if we don't have the secret to decrypt the Google Cloud Storage credentials.

However, this comes with security problems: https://securitylab.github.com/research/github-actions-preventing-pwn-requests. You can do two things, make sure the tests only run when a label is added with someone with write permission, or change repository settings to always require manual approval for running actions for outside contributors. I went with the latter. 