### PR TITLE
Correctly throw error in S3 store and check for file ID in GCSDataStore

### DIFF
--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -209,6 +209,10 @@ class GCSDataStore extends DataStore {
      */
     getOffset(file_id) {
         return new Promise((resolve, reject) => {
+            if (!file_id) {
+                return reject(ERRORS.FILE_NOT_FOUND);
+            }
+
             const file = this.bucket.file(file_id);
             file.getMetadata((error, metadata, apiResponse) => {
                 if (error && error.code === 404) {

--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -210,7 +210,8 @@ class GCSDataStore extends DataStore {
     getOffset(file_id) {
         return new Promise((resolve, reject) => {
             if (!file_id) {
-                return reject(ERRORS.FILE_NOT_FOUND);
+                reject(ERRORS.FILE_NOT_FOUND);
+                return;
             }
 
             const file = this.bucket.file(file_id);

--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -437,13 +437,13 @@ class S3Store extends DataStore {
         delete this.cache[file_id];
     }
 
-    create(req) {
+    async create(req) {
         const upload_length = req.headers['upload-length'];
         const upload_defer_length = req.headers['upload-defer-length'];
         const upload_metadata = req.headers['upload-metadata'];
 
         if (upload_length === undefined && upload_defer_length === undefined) {
-            throw new Error(ERRORS.INVALID_LENGTH);
+            throw ERRORS.INVALID_LENGTH;
         }
 
         let file_id;
@@ -453,7 +453,7 @@ class S3Store extends DataStore {
         }
         catch (err) {
             log('create: check your `namingFunction`. Error', err);
-            throw new Error(ERRORS.FILE_WRITE_ERROR);
+            throw ERRORS.FILE_WRITE_ERROR;
         }
 
         const file = new File(file_id, upload_length, upload_defer_length, upload_metadata);

--- a/test/Test-Stores.shared.js
+++ b/test/Test-Stores.shared.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const should = require('should');
 const sinon = require('sinon')
 const fs = require('fs')
 
@@ -54,16 +55,14 @@ exports.shouldCreateUploads = function () {
       assert.equal(this.server.datastore.hasExtension('creation'), true);
     })
 
-    it('should reject if both upload-length and upload-defer-length are not provided', function (done) {
-      assert.rejects(() => this.server.datastore.create(invalidReq))
-      done()
+    it('should reject if both upload-length and upload-defer-length are not provided', async function () {
+      return assert.rejects(() => this.server.datastore.create(invalidReq), { status_code: 412 })
     })
 
-    it('should reject when namingFunction is invalid', function (done) {
+    it('should reject when namingFunction is invalid', async function () {
       const namingFunction = (incomingReq) => incomingReq.doesnotexist.replace(/\//g, '-')
       this.server.datastore.generateFileName = namingFunction
-      assert.rejects(() => this.server.datastore.create(req))
-      done()
+      return assert.rejects(() => this.server.datastore.create(req), { status_code: 500 })
     })
 
     it('should create a file, process it, and send file created event', async function () {
@@ -110,7 +109,7 @@ exports.shouldRemoveUploads = function () {
       const file = await this.server.datastore.create(req)
       await this.server.datastore.remove({ file_id: file.id })
       assert.equal(fileDeletedEvent.calledOnce, true)
-      assert.rejects(this.server.datastore.remove({ file_id: file.id }))
+      return assert.rejects(this.server.datastore.remove({ file_id: file.id }))
     })
   })
 }
@@ -163,11 +162,11 @@ exports.shouldWriteUploads = function () {
 exports.shouldHandleOffset = function () {
   describe('getOffset', function () {
     it('should reject non-existant files', function () {
-      return this.server.datastore.getOffset('doesnt_exist').should.be.rejectedWith(404)
+      return assert.rejects(() => this.server.datastore.getOffset('doesnt_exist'), { status_code: 404 })
     })
 
     it('should reject directories', function () {
-      return this.server.datastore.getOffset('').should.be.rejectedWith(404)
+      return assert.rejects(() => this.server.datastore.getOffset(''), { status_code: 404 })
     })
 
     it('should resolve the stats for existing files', function (done) {


### PR DESCRIPTION
Errors in S3 store are not throw correctly. `PostHandler` can properly handle errors that have `status_code` properties. If error object is encapsulated in `Error` class then such error can not be properly handled.

This PR also fixes some tests that did not work at all.