### PR TITLE
S3Store: fix broken upload with deferred length or without metadata

### DIFF
--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -128,12 +128,18 @@ class S3Store extends DataStore {
             Bucket: this.bucket_name,
             Key: file.id,
             Metadata: {
-                upload_length: file.upload_length,
                 tus_version: TUS_RESUMABLE,
-                upload_metadata: file.upload_metadata,
-                // upload_defer_length: upload_defer_length,
             },
         };
+
+        if (file.upload_length !== undefined)
+            upload_data.Metadata.upload_length = file.upload_length;
+
+        if (file.upload_defer_length !== undefined)
+            upload_data.Metadata.upload_defer_length = file.upload_defer_length;
+
+        if (file.upload_metadata !== undefined)
+            upload_data.Metadata.upload_metadata = file.upload_metadata;
 
         if (parsedMetadata.contentType) {
             upload_data.ContentType = parsedMetadata.contentType.decoded;
@@ -241,6 +247,10 @@ class S3Store extends DataStore {
    * @return {Object}                 metadata as key-value pair
    */
     _parseMetadataString(metadata_string) {
+        if (!metadata_string) {
+            return {};
+        }
+
         const kv_pair_list = metadata_string.split(',');
 
         return kv_pair_list.reduce((metadata, kv_pair) => {
@@ -248,7 +258,7 @@ class S3Store extends DataStore {
 
             metadata[key] = {
                 encoded: base64_value,
-                decoded: Buffer.from(base64_value, 'base64').toString('ascii'),
+                decoded: base64_value !== undefined ? Buffer.from(base64_value, 'base64').toString('ascii') : undefined,
             };
 
             return metadata;
@@ -551,6 +561,7 @@ class S3Store extends DataStore {
                 ...this.cache[id].file,
                 size: parts.length > 0 ? parts.reduce((a, b) => a + b.Size, 0) : 0,
                 upload_length: metadata.file.upload_length,
+                upload_defer_length: metadata.file.upload_defer_length,
                 parts,
             };
         }
@@ -566,6 +577,7 @@ class S3Store extends DataStore {
                 ...this.cache[id].file,
                 size: metadata.file.upload_length,
                 upload_length: metadata.file.upload_length,
+                upload_defer_length: metadata.file.upload_defer_length
             };
         }
     }

--- a/test/Test-Stores.shared.js
+++ b/test/Test-Stores.shared.js
@@ -65,6 +65,38 @@ exports.shouldCreateUploads = function () {
       return assert.rejects(() => this.server.datastore.create(req), { status_code: 500 })
     })
 
+    it('should create a file with upload-length', async function () {
+      const file = await this.server.datastore.create(req)
+
+      assert.equal(file.upload_length, req.headers['upload-length']);
+      assert.equal(file.upload_defer_length, undefined);
+
+    })
+
+    it('should create a file with upload-defer-length', async function () {
+      const req = {
+        headers: {
+          'upload-defer-length': '1',
+          'upload-metadata': 'foo bar',
+        },
+      };
+      const file = await this.server.datastore.create(req);
+
+      assert.equal(file.upload_defer_length, req.headers['upload-defer-length']);
+      assert.equal(file.upload_length, undefined);
+    })
+
+    it('should create a file without upload-metadata', async function () {
+      const req = {
+        headers: {
+          'upload-length': testFileSize.toString()
+        },
+      };
+      const file = await this.server.datastore.create(req);
+
+      assert.equal(file.upload_metadata, undefined);
+    })
+
     it('should create a file, process it, and send file created event', async function () {
       const fileCreatedEvent = sinon.fake()
 


### PR DESCRIPTION
Fix broken upload with deferred length or without metadata using S3 datastore. This fix is already in #186. This PR will allow us to merge this sooner.