### PR TITLE
Removed/commented assert code on S3 store to have an option to use AW…

### DIFF
--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -55,9 +55,9 @@ class S3Store extends DataStore {
 
         this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length'];
 
-        assert.ok(options.accessKeyId, '[S3Store] `accessKeyId` must be set');
-        assert.ok(options.secretAccessKey, '[S3Store] `secretAccessKey` must be set');
-        assert.ok(options.bucket, '[S3Store] `bucket` must be set');
+        // assert.ok(options.accessKeyId, '[S3Store] `accessKeyId` must be set');
+        // assert.ok(options.secretAccessKey, '[S3Store] `secretAccessKey` must be set');
+        // assert.ok(options.bucket, '[S3Store] `bucket` must be set');
 
         this.tmp_dir_prefix = options.tmpDirPrefix || 'tus-s3-store';
         this.bucket_name = options.bucket;


### PR DESCRIPTION
Removed/commented assert code on S3 store to have an option to use AWS.ECSCredentials
```js
server.datastore = new tus.S3Store({
  path: '/',
  bucket: 'my-bucket',
  credentials: new AWS.ECSCredentials({
    httpOptions: { timeout: 5000 },
    maxRetries: 10,
    retryDelayOptions: { base: 200 },
  }),
  region: 'use-east-1',
  partSize: 8 * 1024 * 1024,
});
```