### PR TITLE
EVENT_UPLOAD_COMPLETE checked in upload-length in last chunk

### DIFF
--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -159,7 +159,7 @@ class FileStore extends DataStore {
                 log(`[FileStore] write: File is now ${offset} bytes`);
 
                 const config = this.configstore.get(file_id);
-                if (config && parseInt(config.upload_length, 10) === offset) {
+                if (config && parseInt(config.upload_length || req.headers['upload-length'], 10) === offset) {
                     this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file: config });
                 }
                 return resolve(offset);


### PR DESCRIPTION
When upload-length-deferred is used in the case of streams, currently the FileStore does not emit EVENT_UPLOAD_COMPLETE event because it does not check the upload-length field of the request header. That's what this commit fixes.