### PR TITLE
GCS: ignore insufficient access error

### DIFF
--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -48,6 +48,11 @@ class GCSDataStore extends DataStore {
     _getBucket() {
         const bucket = this.gcs.bucket(this.bucket_name);
         bucket.exists((error, exists) => {
+            // ignore insufficient access error, assume bucket exists
+            if (error.code === 403) {
+                return;
+            }
+
             if (error) {
                 log(error);
                 throw new Error(`[GCSDataStore] _getBucket: ${error.message}`);
@@ -56,7 +61,6 @@ class GCSDataStore extends DataStore {
             if (!exists) {
                 throw new Error(`[GCSDataStore] _getBucket: ${this.bucket_name} bucket does not exist`);
             }
-
         });
 
         return bucket;


### PR DESCRIPTION
Handle insufficient access error by ignoring it.

Fixes https://github.com/tus/tus-node-server/issues/293