### PR TITLE
Fix upload ID when using S3 store with Digital Ocean Spaces

### DIFF
--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -234,9 +234,8 @@ class S3Store extends DataStore {
             .then((data) => {
                 this.cache[file_id] = Object.assign({}, data.Metadata, {
                     file: JSON.parse(data.Metadata.file),
-                    
                     // Patch for Digital Ocean: if key upload_id (AWS, standard) doesn't exist in Metadata object, fallback to upload-id (DO)
-                    upload_id: data.Metadata.upload_id || data.Metadata['upload-id']
+                    upload_id: data.Metadata.upload_id || data.Metadata['upload-id'],
                 });
 
                 return this.cache[file_id];

--- a/lib/stores/S3Store.js
+++ b/lib/stores/S3Store.js
@@ -234,6 +234,9 @@ class S3Store extends DataStore {
             .then((data) => {
                 this.cache[file_id] = Object.assign({}, data.Metadata, {
                     file: JSON.parse(data.Metadata.file),
+                    
+                    // Patch for Digital Ocean: if key upload_id (AWS, standard) doesn't exist in Metadata object, fallback to upload-id (DO)
+                    upload_id: data.Metadata.upload_id || data.Metadata['upload-id']
                 });
 
                 return this.cache[file_id];


### PR DESCRIPTION
Digital Ocean Spaces (S3 compatible object storage) sends the upload id information in metadata as `upload-id` instead `upload_id`, so the `_getMetadata` method of `S3Store` returns an empty upload id.

This change is a simple patch that works as a fallback to `upload-id` if `upload_id` is not found.