### PR TITLE
Do not run GitHub Actions in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     strategy:
+      # We do not want to run CRUD tests in parallel
+      max-parallel: 1
       matrix:
         node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/


### PR DESCRIPTION
There seems to be a race condition which causes GCS tests to fail. Disabling parallel jobs may fix this. 