### PR TITLE
Fix issue where there is no error checking bucket exists in GCSDataStore

### DIFF
--- a/lib/stores/GCSDataStore.js
+++ b/lib/stores/GCSDataStore.js
@@ -46,7 +46,7 @@ class GCSDataStore extends DataStore {
         const bucket = this.gcs.bucket(this.bucket_name);
         bucket.exists((error, exists) => {
             // ignore insufficient access error, assume bucket exists
-            if (error.code === 403) {
+            if (error && error.code === 403) {
                 return;
             }
 


### PR DESCRIPTION
When the bucket exists then `error` is `null` which causes this code to fail with an error  `TypeError: Cannot read properties of null (reading 'code')`.

We are using `"@google-cloud/storage": "^6.5.2",` but there's no harm in checking if a variable is not null before trying to access a property.

This is with the latest `"tus-node-server": "^0.8.0",` release