### PR TITLE
Emit upload complete event when using creation-with-upload extension

### DIFF
--- a/lib/handlers/PatchHandler.js
+++ b/lib/handlers/PatchHandler.js
@@ -63,7 +63,7 @@ class PatchHandler extends BaseHandler {
         }
 
         const new_offset = await this.store.write(req, file_id, offset);
-        if (parseInt(new_offset, 10) === parseInt(upload_length, 10)) {
+        if (new_offset === parseInt(upload_length, 10)) {
             this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file: new File(file_id, file.upload_length, file.upload_defer_length, file.upload_metadata) });
         }
 

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -65,6 +65,10 @@ class PostHandler extends BaseHandler {
         if (!RequestValidator.isInvalidHeader('content-type', req.headers['content-type'])) {
             const new_offset = await this.store.write(req, file.id, 0);
             optional_headers['Upload-Offset'] = new_offset;
+
+            if (new_offset === parseInt(upload_length, 10)) {
+                this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file: new File(file_id, file.upload_length, file.upload_defer_length, file.upload_metadata) });
+            }
         }
 
         return this.write(res, 201, { Location: url, ...optional_headers });


### PR DESCRIPTION
Event `EVENTS.EVENT_UPLOAD_COMPLETE` is not emitted when upload is completed using `creation-with-upload` extension. 