### PR TITLE
Revert "Bump tus-js-client from 2.3.1 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "should": "^13.2.3",
         "sinon": "^13.0.1",
         "supertest": "^6.2.2",
-        "tus-js-client": "^3.0.0"
+        "tus-js-client": "^2.3.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -901,12 +901,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -3092,9 +3086,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -4264,14 +4258,16 @@
       }
     },
     "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
+      "integrity": "sha1-FZ+wYZPTIAP0s2kd0uwaY0qoDR0=",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/punycode": {
@@ -4440,12 +4436,12 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true,
       "engines": {
-        "node": ">= 4"
+        "node": "*"
       }
     },
     "node_modules/retry-request": {
@@ -4980,19 +4976,25 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tus-js-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-3.0.0.tgz",
-      "integrity": "sha512-PHWI/K8YrCzpc83MqkLhqm89EGG+pPrkBaJ/0NQH0xQoqxfs7HKqAqfXrjmcw2CHZeGYaqxI6oVcolXThzYOSA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.3.1.tgz",
+      "integrity": "sha512-QEM7ySnthWT+wwePLTXVSQP8vBLCy0ZoJNDGFzNlsU+YVoK2WevIZwcRnKyo962xhYMiABe3aMvXvk4Ln+VRzQ==",
       "dev": true,
       "dependencies": {
-        "buffer-from": "^1.1.2",
+        "buffer-from": "^0.1.1",
         "combine-errors": "^3.0.3",
         "is-stream": "^2.0.0",
-        "js-base64": "^3.7.2",
+        "js-base64": "^2.6.1",
         "lodash.throttle": "^4.1.1",
-        "proper-lockfile": "^4.1.2",
+        "proper-lockfile": "^2.0.1",
         "url-parse": "^1.5.7"
       }
+    },
+    "node_modules/tus-js-client/node_modules/buffer-from": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6151,12 +6153,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -7770,9 +7766,9 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-base64": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "js-tokens": {
@@ -8688,14 +8684,13 @@
       "dev": true
     },
     "proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
+      "integrity": "sha1-FZ+wYZPTIAP0s2kd0uwaY0qoDR0=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
       }
     },
     "punycode": {
@@ -8822,9 +8817,9 @@
       "dev": true
     },
     "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true
     },
     "retry-request": {
@@ -9263,18 +9258,26 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tus-js-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-3.0.0.tgz",
-      "integrity": "sha512-PHWI/K8YrCzpc83MqkLhqm89EGG+pPrkBaJ/0NQH0xQoqxfs7HKqAqfXrjmcw2CHZeGYaqxI6oVcolXThzYOSA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.3.1.tgz",
+      "integrity": "sha512-QEM7ySnthWT+wwePLTXVSQP8vBLCy0ZoJNDGFzNlsU+YVoK2WevIZwcRnKyo962xhYMiABe3aMvXvk4Ln+VRzQ==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.1.2",
+        "buffer-from": "^0.1.1",
         "combine-errors": "^3.0.3",
         "is-stream": "^2.0.0",
-        "js-base64": "^3.7.2",
+        "js-base64": "^2.6.1",
         "lodash.throttle": "^4.1.1",
-        "proper-lockfile": "^4.1.2",
+        "proper-lockfile": "^2.0.1",
         "url-parse": "^1.5.7"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
+          "dev": true
+        }
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "should": "^13.2.3",
     "sinon": "^13.0.1",
     "supertest": "^6.2.2",
-    "tus-js-client": "^3.0.0"
+    "tus-js-client": "^2.3.0"
   },
   "dependencies": {
     "@google-cloud/storage": "^6.2.2",


### PR DESCRIPTION
Reverts tus/tus-node-server#289

This upgrade broke `npm run demo`. Problem is that `tus-js-client` 3.0.0 does not install demo folder anymore which is served by our `demo` command.