### PR TITLE
fix validation of upload-length header in patch handler

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -64,6 +64,10 @@ const ERRORS = {
         status_code: 501,
         body: 'Concatenation extension is not (yet) supported. Disable parallel uploads in the tus client.\n',
     },
+    UNSUPPORTED_CREATION_DEFER_LENGTH_EXTENSION: {
+        status_code: 501,
+        body: 'creation-defer-length extension is not (yet) supported.\n',
+    },
 };
 
 const EVENT_ENDPOINT_CREATED = 'EVENT_ENDPOINT_CREATED';

--- a/lib/handlers/PatchHandler.js
+++ b/lib/handlers/PatchHandler.js
@@ -32,14 +32,6 @@ class PatchHandler extends BaseHandler {
             throw ERRORS.INVALID_CONTENT_TYPE;
         }
 
-        // The request MUST validate upload-length related headers
-        const upload_length = req.headers['upload-length'];
-        const upload_defer_length = req.headers['upload-defer-length'];
-
-        if ((upload_length === undefined) === (upload_defer_length === undefined)) {
-            throw ERRORS.INVALID_LENGTH;
-        }
-
         const file = await this.store.getOffset(file_id);
 
         if (file.size !== offset) {
@@ -48,22 +40,29 @@ class PatchHandler extends BaseHandler {
             throw ERRORS.INVALID_OFFSET;
         }
 
-        // Throw error is upload-length header does not match current upload-length if it is set.
-        if (upload_length !== undefined && file.upload_length !== undefined && upload_length !== file.upload_length) {
-            throw ERRORS.INVALID_LENGTH;
-        }
-        // Throw error is upload-defer-length header is present while upload-length is already known
-        else if (upload_defer_length !== undefined && file.upload_length !== undefined) {
-            throw ERRORS.INVALID_LENGTH;
-        }
+        // The request MUST validate upload-length related headers
+        const upload_length = req.headers['upload-length'];
+        if (upload_length !== undefined) {
+            // Throw error if extension is not supported
+            if (!this.store.hasExtension('creation-defer-length')) {
+                throw ERRORS.UNSUPPORTED_CREATION_DEFER_LENGTH_EXTENSION;
+            }
 
-        // Declare upload-length if it is not already known
-        if (upload_length !== undefined && file.upload_length === undefined) {
+            // Throw error if upload-length is already set.
+            if (file.upload_length !== undefined) {
+                throw ERRORS.INVALID_LENGTH;
+            }
+
+            if (parseInt(upload_length, 10) < file.size) {
+                throw ERRORS.INVALID_LENGTH;
+            }
+
             await this.store.declareUploadLength(file_id, upload_length);
+            file.upload_length = upload_length;
         }
 
         const new_offset = await this.store.write(req, file_id, offset);
-        if (parseInt(new_offset, 10) === parseInt(upload_length, 10)) {
+        if (new_offset === parseInt(file.upload_length, 10)) {
             this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, { file: new File(file_id, file.upload_length, file.upload_defer_length, file.upload_metadata) });
         }
 

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -37,6 +37,13 @@ class PostHandler extends BaseHandler {
         const upload_defer_length = req.headers['upload-defer-length'];
         const upload_metadata = req.headers['upload-metadata'];
 
+        if (upload_defer_length !== undefined) {
+            // Throw error if extension is not supported
+            if (!this.store.hasExtension('creation-defer-length')) {
+                throw ERRORS.UNSUPPORTED_CREATION_DEFER_LENGTH_EXTENSION;
+            }
+        }
+
         if ((upload_length === undefined) === (upload_defer_length === undefined)) {
             throw ERRORS.INVALID_LENGTH;
         }

--- a/lib/stores/DataStore.js
+++ b/lib/stores/DataStore.js
@@ -85,7 +85,7 @@ class DataStore extends EventEmitter {
      * Called in PATCH requests when upload length is known after being defered.
      *
      * @param {string} file_id Name of file
-     * @param {number} upload_length Declared upload length
+     * @param {string} upload_length Declared upload length
      * @return {Promise}
      */
     async declareUploadLength(file_id, upload_length) {

--- a/test/Test-EndToEnd.js
+++ b/test/Test-EndToEnd.js
@@ -219,7 +219,6 @@ describe('EndToEnd', () => {
                 const write_stream = agent.patch(`${STORE_PATH}/${file_id}`)
                     .set('Tus-Resumable', TUS_RESUMABLE)
                     .set('Upload-Offset', 0)
-                    .set('Upload-Length', TEST_FILE_SIZE)
                     .set('Content-Type', 'application/offset+octet-stream');
 
                 write_stream.on('response', (res) => {
@@ -471,7 +470,6 @@ describe('EndToEnd', () => {
                 const write_stream = agent.patch(`${STORE_PATH}/${file_id}`)
                     .set('Tus-Resumable', TUS_RESUMABLE)
                     .set('Upload-Offset', 0)
-                    .set('Upload-Length', `${TEST_FILE_SIZE}`)
                     .set('Content-Type', 'application/offset+octet-stream');
 
                 write_stream.on('response', (res) => {

--- a/test/Test-PostHandler.js
+++ b/test/Test-PostHandler.js
@@ -170,6 +170,7 @@ describe('PostHandler', () => {
                 
                 fake_store.create.resolvesArg(0);
                 fake_store.write.resolves(upload_length);
+                fake_store.hasExtension.withArgs('creation-defer-length').returns(true);
 
                 const handler = new PostHandler(fake_store, { path: '/test/output' });
                 handler.on(EVENTS.EVENT_UPLOAD_COMPLETE, (obj) => {

--- a/test/Test-PostHandler.js
+++ b/test/Test-PostHandler.js
@@ -21,6 +21,7 @@ describe('PostHandler', () => {
     let res = null;
 
     const fake_store = sinon.createStubInstance(DataStore);
+    fake_store.hasExtension.withArgs('creation-defer-length').returns(true);
 
     beforeEach((done) => {
         req = { headers: {}, url: '/files', host: 'localhost:3000' };

--- a/test/Test-Server.js
+++ b/test/Test-Server.js
@@ -305,7 +305,6 @@ describe('Server', () => {
                         .send('test')
                         .set('Tus-Resumable', TUS_RESUMABLE)
                         .set('Upload-Offset', 0)
-                        .set('Upload-Length', Buffer.byteLength('test', 'utf8'))
                         .set('Content-Type', 'application/offset+octet-stream')
                         .end((err) => { if (err) done(err) });
                 })


### PR DESCRIPTION
I made a mistake in #297 thinking that either `Upload-Length` or `Upload-Defer-Length` headers MUST be present. This PR fixes this.

We don't need to validate `Upload-Defer-Length` as it is not expected to be present. `Upload-Length` can ONLY be present if extension is supported, and upload length is not yet known.