### PR TITLE
Clarify example for Fastify

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ const fastify = require('fastify')({ logger: true });
  * @see https://www.fastify.io/docs/latest/Reference/ContentTypeParser/
  */
 fastify.addContentTypeParser(
-    'application/offset+octet-stream', async () => true
+    'application/offset+octet-stream', (request, payload, done) => done(null)
 );
 
 /**


### PR DESCRIPTION
Some linters (or personal preference) remove `async` from functions if there are no `await` or return a `Promise` object. This, with some bad errors management in Fastify, has lead me to two full week of head banging. With the sync signature, it gets more explicit that the body parsing always succeed by doing nothing.

Note: `null` is needed due to how Typescript types are defined, for regular Javascript just calling `done()` should works.