### PR TITLE
Added expiration extension for FileStore

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare interface DataStoreOptions {}
 declare interface FileStoreOptions extends DataStoreOptions {
     directory: string;
     configstore?: Configstore;
+    expirationPeriodMinutes?: number;
 }
 
 declare interface GCStoreOptions extends DataStoreOptions {
@@ -52,6 +53,7 @@ declare class File {
         upload_defer_length: string,
         upload_metadata: string
     );
+    creation_date: Date;
 }
 
 /**
@@ -72,6 +74,7 @@ export declare class DataStore extends EventEmitter {
         offset: number
     ): Promise<number>;
     getOffset(file_id: string): Promise<IFile>;
+    deleteExpired(): Promise<void>;
 }
 
 export declare class DeferableLengthDatastore extends DataStore {
@@ -113,6 +116,7 @@ export declare class Server extends EventEmitter {
         res: http.ServerResponse
     ): http.ServerResponse;
     listen(): http.Server;
+    cleanUpExpiredUploads(): Promise<void>;
 }
 
 export declare const EVENTS: {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -199,6 +199,21 @@ class TusServer extends EventEmitter {
         const server = http.createServer(this.handle.bind(this));
         return server.listen.apply(server, arguments);
     }
+
+    /**
+     * Removes incomplete uploads that are older than the expiration period
+     * (if the expiration period is defined).
+     */
+    cleanUpExpiredUploads() {
+        if (!this.datastore.hasExtension('expiration')) {
+            throw ERRORS.UNSUPPORTED_EXPIRATION_EXTENSION;
+        }
+
+        if (this.datastore.expirationPeriodMinutes &&
+            this.datastore.deleteExpired) {
+            this.datastore.deleteExpired();
+        }
+    }
 }
 
 module.exports = TusServer;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -68,6 +68,10 @@ const ERRORS = {
         status_code: 501,
         body: 'creation-defer-length extension is not (yet) supported.\n',
     },
+    UNSUPPORTED_EXPIRATION_EXTENSION: {
+        status_code: 501,
+        body: 'expiration extension is not (yet) supported.\n',
+    },
 };
 
 const EVENT_ENDPOINT_CREATED = 'EVENT_ENDPOINT_CREATED';

--- a/lib/handlers/PatchHandler.js
+++ b/lib/handlers/PatchHandler.js
@@ -71,6 +71,15 @@ class PatchHandler extends BaseHandler {
             'Upload-Offset': new_offset,
         };
 
+        // "Upload-Exipres response headers indicate the time after which the unfinished upload expires."
+        // The header MUST be include if the upload is going to expire.
+        if (this.store.hasExtension('expiration') && this.store.expirationPeriodMinutes &&
+            new_offset < parseInt(file.upload_length, 10)) {
+            const creation = new Date(file.creation_date);
+            // value MUST be in RFC 7231 datetime format
+            headers['Upload-Expires'] = new Date(creation.getTime() + this.store.expirationPeriodMinutes*60000).toUTCString();
+        }
+
         // The Server MUST acknowledge successful PATCH requests with the 204
         return this.write(res, 204, headers);
     }

--- a/lib/handlers/PostHandler.js
+++ b/lib/handlers/PostHandler.js
@@ -78,6 +78,16 @@ class PostHandler extends BaseHandler {
             }
         }
 
+        // If expiration is known at creation time, Upload-Expires header MUST be included in the response
+        const stats = await this.store.getOffset(file.id)
+        const size = parseInt(stats.size, 10);
+        if (this.store.hasExtension('expiration') && this.store.expirationPeriodMinutes &&
+            size < parseInt(upload_length, 10)) {
+            const creation = new Date(file.creation_date);
+            // value MUST be in RFC 7231 datetime format
+            optional_headers['Upload-Expires'] = new Date(creation.getTime() + this.store.expirationPeriodMinutes*60000).toUTCString();
+        }
+
         return this.write(res, 201, { Location: url, ...optional_headers });
     }
 }

--- a/lib/models/File.js
+++ b/lib/models/File.js
@@ -21,6 +21,8 @@ class File {
         this.upload_length = upload_length;
         this.upload_defer_length = upload_defer_length;
         this.upload_metadata = upload_metadata;
+
+        this.creation_date = new Date();
     }
 }
 

--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -25,12 +25,13 @@ class FileStore extends DataStore {
         super(options);
         this.directory = options.directory;
         this.configstore = options.configstore;
+        this.expirationPeriodMinutes = options.expirationPeriodMinutes;
 
         if (!this.configstore) {
             this.configstore = new Configstore(`${pkg.name}-${pkg.version}`);
         }
 
-        this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length', 'termination'];
+        this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length', 'termination', 'expiration'];
         this._checkOrCreateDirectory();
     }
 
@@ -193,6 +194,25 @@ class FileStore extends DataStore {
         file.upload_defer_length = undefined;
 
         this.configstore.set(file_id, file);
+    }
+
+    async deleteExpired() {
+        const now = new Date();
+        for (const file_id of Object.keys(this.configstore.all)) {
+            const info = this.configstore.get(file_id);
+            const stats = await this.getOffset(file_id);
+            const upload_length = parseInt(stats.upload_length, 10);
+            const size_on_disk = stats.size;
+            if (size_on_disk === upload_length) {
+                continue; // upload is complete, so don't delete
+            }
+
+            const creation = new Date(info.creation_date);
+            const expires = new Date(creation.getTime() + this.expirationPeriodMinutes*60000);
+            if (now > expires) {
+                this.remove(file_id);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Server owners to configure expiration time with expirationPeriodMintues property in FileStoreOptions. Then, the server owner can periodically invoke Server::cleanUpExpiredUploads() to remove uploads that are both expired AND imcomplete.