### PR TITLE
Rename `getOffset` to `getUpload`

### DIFF
--- a/lib/handlers/GetHandler.ts
+++ b/lib/handlers/GetHandler.ts
@@ -38,7 +38,7 @@ export default class GetHandler extends BaseHandler {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    const stats = await this.store.getOffset(file_id)
+    const stats = await this.store.getUpload(file_id)
     const upload_length = Number.parseInt(stats.upload_length as string, 10)
     if (stats.size !== upload_length) {
       log(

--- a/lib/handlers/HeadHandler.ts
+++ b/lib/handlers/HeadHandler.ts
@@ -11,7 +11,7 @@ export default class HeadHandler extends BaseHandler {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    const file = await this.store.getOffset(file_id)
+    const file = await this.store.getUpload(file_id)
     // The Server MUST prevent the client and/or proxies from
     // caching the response by adding the Cache-Control: no-store
     // header to the response.

--- a/lib/handlers/PatchHandler.ts
+++ b/lib/handlers/PatchHandler.ts
@@ -31,7 +31,7 @@ export default class PatchHandler extends BaseHandler {
       throw ERRORS.INVALID_CONTENT_TYPE
     }
 
-    const file = await this.store.getOffset(file_id)
+    const file = await this.store.getUpload(file_id)
 
     if (file.size !== offset) {
       // If the offsets do not match, the Server MUST respond with the 409 Conflict status without modifying the upload resource.

--- a/lib/stores/DataStore.ts
+++ b/lib/stores/DataStore.ts
@@ -60,7 +60,7 @@ export default class DataStore extends EventEmitter {
    * writen to the DataStore, for the client to know where to resume
    * the upload.
    */
-  async getOffset(file_id: string): Promise<File> {
+  async getUpload(file_id: string): Promise<File> {
     return {id: file_id, size: 0, upload_length: '0'}
   }
 

--- a/lib/stores/FileStore.ts
+++ b/lib/stores/FileStore.ts
@@ -139,7 +139,7 @@ export default class FileStore extends DataStore {
     })
   }
 
-  async getOffset(file_id: string): Promise<File> {
+  async getUpload(file_id: string): Promise<File> {
     const file = this.configstore.get(file_id)
 
     if (!file) {
@@ -151,14 +151,14 @@ export default class FileStore extends DataStore {
       fs.stat(file_path, (error, stats) => {
         if (error && error.code === FILE_DOESNT_EXIST && file) {
           log(
-            `[FileStore] getOffset: No file found at ${file_path} but db record exists`,
+            `[FileStore] getUpload: No file found at ${file_path} but db record exists`,
             file
           )
           return reject(ERRORS.FILE_NO_LONGER_EXISTS)
         }
 
         if (error && error.code === FILE_DOESNT_EXIST) {
-          log(`[FileStore] getOffset: No file found at ${file_path}`)
+          log(`[FileStore] getUpload: No file found at ${file_path}`)
           return reject(ERRORS.FILE_NOT_FOUND)
         }
 
@@ -167,7 +167,7 @@ export default class FileStore extends DataStore {
         }
 
         if (stats.isDirectory()) {
-          log(`[FileStore] getOffset: ${file_path} is a directory`)
+          log(`[FileStore] getUpload: ${file_path} is a directory`)
           return reject(ERRORS.FILE_NOT_FOUND)
         }
 

--- a/lib/stores/GCSDataStore.ts
+++ b/lib/stores/GCSDataStore.ts
@@ -105,7 +105,7 @@ export default class GCSDataStore extends DataStore {
   ): Promise<number> {
     // GCS Doesn't persist metadata within versions,
     // get that metadata first
-    return this.getOffset(file_id).then((data) => {
+    return this.getUpload(file_id).then((data) => {
       return new Promise((resolve, reject) => {
         const file = this.bucket.file(file_id)
         const destination = data.size === 0 ? file : this.bucket.file(`${file_id}_patch`)
@@ -160,7 +160,7 @@ export default class GCSDataStore extends DataStore {
     })
   }
 
-  getOffset(file_id: string): Promise<File> {
+  getUpload(file_id: string): Promise<File> {
     return new Promise((resolve, reject) => {
       if (!file_id) {
         reject(ERRORS.FILE_NOT_FOUND)
@@ -204,7 +204,7 @@ export default class GCSDataStore extends DataStore {
   }
 
   async declareUploadLength(file_id: string, upload_length: string) {
-    const metadata = await this.getOffset(file_id)
+    const metadata = await this.getUpload(file_id)
     metadata.upload_length = upload_length
     // NOTE: this needs to be `null` and not `undefined`,
     // GCS has logic that if it's the latter, it will keep the previous value ¯\_(ツ)_/¯

--- a/lib/stores/S3Store.ts
+++ b/lib/stores/S3Store.ts
@@ -442,7 +442,7 @@ class S3Store extends DataStore {
   ): Promise<number> {
     return this._getMetadata(file_id)
       .then((metadata) => {
-        return Promise.all([metadata, this._countParts(file_id), this.getOffset(file_id)])
+        return Promise.all([metadata, this._countParts(file_id), this.getUpload(file_id)])
       })
       .then(async (results) => {
         const [metadata, part_number, initial_offset] = results
@@ -455,7 +455,7 @@ class S3Store extends DataStore {
             initial_offset.size
           )
         )
-          .then(() => this.getOffset(file_id))
+          .then(() => this.getUpload(file_id))
           .then((current_offset) => {
             if (
               Number.parseInt(metadata.file.upload_length as string, 10) ===
@@ -491,7 +491,7 @@ class S3Store extends DataStore {
                 )
               }
 
-              return this.getOffset(file_id).then((current_offset) => current_offset.size)
+              return this.getUpload(file_id).then((current_offset) => current_offset.size)
             }
 
             this._clearCache(file_id)
@@ -501,12 +501,12 @@ class S3Store extends DataStore {
       })
   }
 
-  async getOffset(id: string): Promise<File & {parts?: aws.S3.Parts; size: number}> {
+  async getUpload(id: string): Promise<File & {parts?: aws.S3.Parts; size: number}> {
     let metadata: MetadataValue | undefined
     try {
       metadata = await this._getMetadata(id)
     } catch (error) {
-      log('getOffset: No file found.', error)
+      log('getUpload: No file found.', error)
       throw ERRORS.FILE_NOT_FOUND
     }
 

--- a/test/Test-DataStore.ts
+++ b/test/Test-DataStore.ts
@@ -49,9 +49,9 @@ describe('DataStore', () => {
     done()
   })
 
-  it('must have a getOffset method', (done) => {
-    datastore.should.have.property('getOffset')
-    datastore.getOffset.should.be.type('function')
+  it('must have a getUpload method', (done) => {
+    datastore.should.have.property('getUpload')
+    datastore.getUpload.should.be.type('function')
     done()
   })
 })

--- a/test/Test-FileStore.ts
+++ b/test/Test-FileStore.ts
@@ -80,9 +80,9 @@ describe('FileStore', function () {
     })
   })
 
-  describe('getOffset', () => {
+  describe('getUpload', () => {
     it('should reject directories', function () {
-      return this.datastore.getOffset('').should.be.rejected()
+      return this.datastore.getUpload('').should.be.rejected()
     })
   })
 

--- a/test/Test-HeadHandler.ts
+++ b/test/Test-HeadHandler.ts
@@ -23,7 +23,7 @@ describe('HeadHandler', () => {
   })
 
   it('should 404 if no file id match', () => {
-    fake_store.getOffset.rejects(ERRORS.FILE_NOT_FOUND)
+    fake_store.getUpload.rejects(ERRORS.FILE_NOT_FOUND)
     return assert.rejects(() => handler.send(req, res), {status_code: 404})
   })
 
@@ -33,7 +33,7 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve with the offset and cache-control', async () => {
-    fake_store.getOffset.resolves({id: '1234', size: 0, upload_length: '1'})
+    fake_store.getUpload.resolves({id: '1234', size: 0, upload_length: '1'})
     await handler.send(req, res)
     assert.equal(res.getHeader('Upload-Offset'), '0')
     assert.equal(res.getHeader('Cache-Control'), 'no-store')
@@ -47,7 +47,7 @@ describe('HeadHandler', () => {
       upload_length: '1',
       upload_metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
     }
-    fake_store.getOffset.resolves(file)
+    fake_store.getUpload.resolves(file)
     await handler.send(req, res)
     assert.equal(res.getHeader('Upload-Length'), file.upload_length)
     assert.equal(res.hasHeader('Upload-Defer-Length'), false)
@@ -60,7 +60,7 @@ describe('HeadHandler', () => {
       upload_defer_length: '1',
       upload_metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
     }
-    fake_store.getOffset.resolves(file)
+    fake_store.getUpload.resolves(file)
     await handler.send(req, res)
     assert.equal(res.getHeader('Upload-Defer-Length'), file.upload_defer_length)
     assert.equal(res.hasHeader('Upload-Length'), false)
@@ -73,14 +73,14 @@ describe('HeadHandler', () => {
       upload_length: '1',
       upload_metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
     }
-    fake_store.getOffset.resolves(file)
+    fake_store.getUpload.resolves(file)
     await handler.send(req, res)
     assert.equal(res.getHeader('Upload-Metadata'), file.upload_metadata)
   })
 
   it('should resolve without metadata', async () => {
     const file = {id: '1234', size: 0, upload_length: '1'}
-    fake_store.getOffset.resolves(file)
+    fake_store.getUpload.resolves(file)
     await handler.send(req, res)
     assert.equal(res.hasHeader('Upload-Metadata'), false)
   })

--- a/test/Test-PatchHandler.ts
+++ b/test/Test-PatchHandler.ts
@@ -64,7 +64,7 @@ describe('PatchHandler', () => {
       req.url = `${path}/file`
 
       store.hasExtension.withArgs('creation-defer-length').returns(true)
-      store.getOffset.resolves({id: '1234', size: 0, upload_defer_length: '1'})
+      store.getUpload.resolves({id: '1234', size: 0, upload_defer_length: '1'})
       store.write.resolves(5)
       store.declareUploadLength.resolves()
 
@@ -81,7 +81,7 @@ describe('PatchHandler', () => {
       }
       req.url = `${path}/file`
 
-      store.getOffset.resolves({id: '1234', size: 0, upload_length: '20'})
+      store.getUpload.resolves({id: '1234', size: 0, upload_length: '20'})
       store.hasExtension.withArgs('creation-defer-length').returns(true)
 
       return assert.rejects(() => handler.send(req, res), {status_code: 400})
@@ -106,7 +106,7 @@ describe('PatchHandler', () => {
       }
       req.url = `${path}/1234`
 
-      store.getOffset.resolves({id: '1234', size: 0, upload_length: '512'})
+      store.getUpload.resolves({id: '1234', size: 0, upload_length: '512'})
 
       return assert.rejects(() => handler.send(req, res), {status_code: 409})
     })
@@ -118,7 +118,7 @@ describe('PatchHandler', () => {
       }
       req.url = `${path}/1234`
 
-      store.getOffset.resolves({id: '1234', size: 0, upload_length: '1024'})
+      store.getUpload.resolves({id: '1234', size: 0, upload_length: '1024'})
       store.write.resolves(10)
 
       await handler.send(req, res)

--- a/test/Test-Stores.shared.ts
+++ b/test/Test-Stores.shared.ts
@@ -12,8 +12,8 @@ export const shouldHaveStoreMethods = function () {
       done()
     })
 
-    it('must have a getOffset method', function (done) {
-      this.datastore.should.have.property('getOffset')
+    it('must have a getUpload method', function (done) {
+      this.datastore.should.have.property('getUpload')
       done()
     })
   })
@@ -40,25 +40,25 @@ export const shouldCreateUploads = function () {
 
     it('should create new upload resource', async function () {
       await this.datastore.create(file)
-      const data = await this.datastore.getOffset(file.id)
+      const data = await this.datastore.getUpload(file.id)
       assert.equal(data.size, 0)
     })
 
     it('should store `upload_length` when creating new resource', async function () {
       await this.datastore.create(file)
-      const data = await this.datastore.getOffset(file.id)
+      const data = await this.datastore.getUpload(file.id)
       assert.strictEqual(data.upload_length, file.upload_length)
     })
 
     it('should store `upload_defer_length` when creating new resource', async function () {
       await this.datastore.create(file_defered)
-      const data = await this.datastore.getOffset(file.id)
+      const data = await this.datastore.getUpload(file.id)
       assert.strictEqual(data.upload_defer_length, file_defered.upload_defer_length)
     })
 
     it('should store `upload_metadata` when creating new resource', async function () {
       await this.datastore.create(file)
-      const data = await this.datastore.getOffset(file.id)
+      const data = await this.datastore.getUpload(file.id)
       assert.strictEqual(data.upload_metadata, file.upload_metadata)
     })
   })
@@ -129,7 +129,7 @@ export const shouldWriteUploads = function () {
 }
 
 export const shouldHandleOffset = function () {
-  describe('getOffset', function () {
+  describe('getUpload', function () {
     const file = new File(
       '1234',
       // @ts-expect-error todo
@@ -139,7 +139,7 @@ export const shouldHandleOffset = function () {
     )
 
     it('should reject non-existant files', function () {
-      return this.datastore.getOffset('doesnt_exist').should.be.rejected()
+      return this.datastore.getUpload('doesnt_exist').should.be.rejected()
     })
 
     it('should resolve the stats for existing files', async function () {
@@ -149,7 +149,7 @@ export const shouldHandleOffset = function () {
         file.id,
         0
       )
-      const data = await this.datastore.getOffset(file.id)
+      const data = await this.datastore.getUpload(file.id)
       assert.equal(data.size, offset)
     })
   })
@@ -170,11 +170,11 @@ export const shouldDeclareUploadLength = function () {
 
     it('should update upload_length after declaring upload length', async function () {
       await this.datastore.create(file)
-      let data = await this.datastore.getOffset(file.id)
+      let data = await this.datastore.getUpload(file.id)
       assert.equal(data.upload_length, undefined)
       assert.equal(data.upload_defer_length, '1')
       await this.datastore.declareUploadLength(file.id, '10')
-      data = await this.datastore.getOffset(file.id)
+      data = await this.datastore.getUpload(file.id)
       assert.equal(data.upload_length, '10')
       assert.equal(data.upload_defer_length, undefined)
     })


### PR DESCRIPTION
`getOffset` implies returning a number, the offset. Instead we return more information so `getUpload` seems better suited and aligned with `tusd`.

### Questions

Do we want to rename the keys of the return value, and the `File` model too? From:

```ts
  id: string
  upload_defer_length?: string
  upload_metadata?: string
  upload_length?: string
  size?: number
```

To:

```ts
  id: string
  isDeferred?: boolean
  metadata?: string
  length?: string
  size?: number
```