### PR TITLE
Added implementation of expiration extension to FileStore

### DIFF
--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -195,4 +195,12 @@ export class Server extends EventEmitter {
     const server = http.createServer(this.handle.bind(this))
     return server.listen.apply(server)
   }
+
+  cleanUpExpiredUploads(): Promise<number> {
+    if (!this.datastore.hasExtension('expiration')) {
+      throw ERRORS.UNSUPPORTED_EXPIRATION_EXTENSION
+    }
+
+    return this.datastore.deleteExpired()
+  }
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -59,6 +59,10 @@ export const ERRORS = {
     status_code: 501,
     body: 'creation-defer-length extension is not (yet) supported.\n',
   },
+  UNSUPPORTED_EXPIRATION_EXTENSION: {
+    status_code: 501,
+    body: 'expiration extension is not (yet) supported.\n',
+  },
 } as const
 export const EVENT_ENDPOINT_CREATED = 'EVENT_ENDPOINT_CREATED' as const
 export const EVENT_FILE_CREATED = 'EVENT_FILE_CREATED' as const

--- a/lib/handlers/PatchHandler.ts
+++ b/lib/handlers/PatchHandler.ts
@@ -74,9 +74,24 @@ export default class PatchHandler extends BaseHandler {
       })
     }
 
-    //  It MUST include the Upload-Offset header containing the new offset.
-    const headers = {
+    const headers: {
+      'Upload-Offset': number
+      'Upload-Expires'?: string
+    } = {
       'Upload-Offset': new_offset,
+    }
+
+    if (
+      this.store.hasExtension('expiration') &&
+      this.store.getExpiration() > 0 &&
+      new_offset < Number.parseInt(file.upload_length as string, 10)
+    ) {
+      const creation = new Date(file.creation_date as Date)
+      // Value MUST be in RFC 7231 datetime format
+      const dateString = new Date(
+        creation.getTime() + this.store.getExpiration() * 60_000
+      ).toUTCString()
+      headers['Upload-Expires'] = dateString
     }
 
     // The Server MUST acknowledge successful PATCH requests with the 204

--- a/lib/models/File.ts
+++ b/lib/models/File.ts
@@ -4,6 +4,7 @@ export default class File {
   upload_metadata?: string
   upload_length?: string
   size?: number
+  creation_date?: Date
 
   constructor(
     file_id: string,
@@ -25,5 +26,7 @@ export default class File {
     this.upload_length = upload_length
     this.upload_defer_length = upload_defer_length
     this.upload_metadata = upload_metadata
+
+    this.creation_date = new Date()
   }
 }

--- a/lib/stores/DataStore.ts
+++ b/lib/stores/DataStore.ts
@@ -68,4 +68,15 @@ export default class DataStore extends EventEmitter {
    * Called in PATCH requests when upload length is known after being defered.
    */
   async declareUploadLength(file_id: string, upload_length: string) {}
+
+  /**
+   * Returns number of expired uploads that were deleted.
+   */
+  async deleteExpired(): Promise<number> {
+    return 0
+  }
+
+  getExpiration(): number {
+    return 0
+  }
 }


### PR DESCRIPTION
Server owners to configure expiration time with expirationPeriodMintues property in FileStoreOptions. Then, the server owner can periodically invoke Server::cleanUpExpiredUploads() to remove uploads that are both expired AND incomplete.