### PR TITLE
Respect forwarded headers

### DIFF
--- a/lib/handlers/BaseHandler.ts
+++ b/lib/handlers/BaseHandler.ts
@@ -30,12 +30,13 @@ export default class BaseHandler extends EventEmitter {
   generateUrl(req: http.IncomingMessage, id: string) {
     const forwarded = req.headers.Forwarded as string | undefined
     const path = this.options.path === '/' ? '' : this.options.path
+    // @ts-expect-error baseUrl type doesn't exist?
+    const baseUrl = req.baseUrl ?? ''
     let proto
     let host
 
     if (this.options.relativeLocation) {
-      // @ts-expect-error baseUrl type doesn't exist?
-      return `${req.baseUrl || ''}${path}/${id}`
+      return `${baseUrl}${path}/${id}`
     }
 
     if (this.options.respectForwardedHeaders) {
@@ -58,8 +59,7 @@ export default class BaseHandler extends EventEmitter {
     host ??= req.headers.host
     proto ??= 'http'
 
-    // @ts-expect-error baseUrl type doesn't exist?
-    return `${proto}://${host}${req.baseUrl ?? ''}${path}/${id}`
+    return `${proto}://${host}${baseUrl}${path}/${id}`
   }
 
   getFileIdFromRequest(req: http.IncomingMessage) {

--- a/lib/handlers/BaseHandler.ts
+++ b/lib/handlers/BaseHandler.ts
@@ -28,7 +28,7 @@ export default class BaseHandler extends EventEmitter {
   }
 
   generateUrl(req: http.IncomingMessage, id: string) {
-    const forwarded = req.headers.Forwarded as string
+    const forwarded = req.headers.Forwarded as string | undefined
     const path = this.options.path === '/' ? '' : this.options.path
 
     if (this.options.respectForwardedHeaders) {

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -106,7 +106,7 @@ describe('PostHandler', () => {
         await handler.send(req, res)
         assert.equal(
           // @ts-expect-error works but not in types
-          res._header.includes('Location: //localhost:3000/test/output/1234'),
+          res._header.includes('Location: http://localhost:3000/test/output/1234'),
           true
         )
         assert.equal(res.statusCode, 201)
@@ -160,7 +160,7 @@ describe('PostHandler', () => {
         await handler.send(req, res)
         assert.equal(
           // @ts-expect-error works but not in types
-          res._header.includes('Location: //localhost:3000/test/output/1234'),
+          res._header.includes('Location: http://localhost:3000/test/output/1234'),
           true
         )
         assert.equal(res.statusCode, 201)
@@ -175,7 +175,7 @@ describe('PostHandler', () => {
         await handler.send(req, res)
         assert.equal(
           // @ts-expect-error works but not in types
-          res._header.includes('Location: //localhost:3000/test/output/1234'),
+          res._header.includes('Location: http://localhost:3000/test/output/1234'),
           true
         )
         assert.equal(res.statusCode, 201)
@@ -191,7 +191,7 @@ describe('PostHandler', () => {
         await handler.send(req, res)
         assert.equal(
           // @ts-expect-error works but not in types
-          res._header.includes('Location: //localhost:3000/1234'),
+          res._header.includes('Location: http://localhost:3000/1234'),
           true
         )
         assert.equal(res.statusCode, 201)
@@ -226,7 +226,7 @@ describe('PostHandler', () => {
           namingFunction: () => '1234',
         })
         handler.on(EVENTS.EVENT_ENDPOINT_CREATED, (obj) => {
-          assert.strictEqual(obj.url, '//localhost:3000/test/output/1234')
+          assert.strictEqual(obj.url, 'http://localhost:3000/test/output/1234')
           done()
         })
 

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -113,6 +113,91 @@ describe('PostHandler', () => {
       })
     })
 
+    describe('respect forwarded headers', () => {
+      const handler = new PostHandler(fake_store, {
+        path: '/test/output',
+        respectForwardedHeaders: true,
+        namingFunction: () => '1234',
+      })
+
+      it('should handle X-Forwarded-Host with X-Forwarded-Proto', async () => {
+        req.headers = {
+          'upload-length': '1000',
+          host: 'localhost:3000',
+          'X-Forwarded-Host': 'foo.com',
+          'X-Forwarded-Proto': 'https',
+        }
+        await handler.send(req, res)
+        assert.equal(
+          // @ts-expect-error works but not in types
+          res._header.includes('Location: https://foo.com/test/output/1234'),
+          true
+        )
+        assert.equal(res.statusCode, 201)
+      })
+
+      it('should handle Forwarded', async () => {
+        req.headers = {
+          'upload-length': '1000',
+          host: 'localhost:3000',
+          Forwarded: 'for=localhost:3000;by=203.0.113.60;proto=https;host=foo.com',
+        }
+        await handler.send(req, res)
+        assert.equal(
+          // @ts-expect-error works but not in types
+          res._header.includes('Location: https://foo.com/test/output/1234'),
+          true
+        )
+        assert.equal(res.statusCode, 201)
+      })
+
+      it('should fallback on invalid Forwarded', async () => {
+        req.headers = {
+          'upload-length': '1000',
+          host: 'localhost:3000',
+          Forwarded: 'invalid',
+        }
+        await handler.send(req, res)
+        assert.equal(
+          // @ts-expect-error works but not in types
+          res._header.includes('Location: //localhost:3000/test/output/1234'),
+          true
+        )
+        assert.equal(res.statusCode, 201)
+      })
+
+      it('should fallback on invalid X-Forwarded headers', async () => {
+        req.headers = {
+          'upload-length': '1000',
+          host: 'localhost:3000',
+          'X-Forwarded-Proto': 'foo',
+        }
+        await handler.send(req, res)
+        assert.equal(
+          // @ts-expect-error works but not in types
+          res._header.includes('Location: //localhost:3000/test/output/1234'),
+          true
+        )
+        assert.equal(res.statusCode, 201)
+      })
+
+      it('should handle root as path', async () => {
+        const handler = new PostHandler(fake_store, {
+          path: '/',
+          respectForwardedHeaders: true,
+          namingFunction: () => '1234',
+        })
+        req.headers = {'upload-length': '1000', host: 'localhost:3000'}
+        await handler.send(req, res)
+        assert.equal(
+          // @ts-expect-error works but not in types
+          res._header.includes('Location: //localhost:3000/1234'),
+          true
+        )
+        assert.equal(res.statusCode, 201)
+      })
+    })
+
     describe('events', () => {
       it(`must fire the ${EVENTS.EVENT_FILE_CREATED} event`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)

--- a/test/Test-Server.ts
+++ b/test/Test-Server.ts
@@ -10,6 +10,9 @@ import FileStore from '../lib/stores/FileStore'
 import DataStore from '../lib/stores/DataStore'
 import {TUS_RESUMABLE, EVENTS} from '../lib/constants'
 
+// Test server crashes on http://{some-ip} so we remove the protocol...
+const removeProtocol = (location: string) => location.slice(6)
+
 describe('Server', () => {
   describe('instantiation', () => {
     it('constructor must require options', () => {
@@ -186,7 +189,7 @@ describe('Server', () => {
         .set('Upload-Length', '12345678')
         .then((res) => {
           request(server.listen())
-            .delete(res.headers.location)
+            .delete(removeProtocol(res.headers.location))
             .set('Tus-Resumable', TUS_RESUMABLE)
             .expect(204, done)
         })
@@ -293,7 +296,7 @@ describe('Server', () => {
         .set('Upload-Length', '12345678')
         .then((res) => {
           request(server.listen())
-            .delete(res.headers.location)
+            .delete(removeProtocol(res.headers.location))
             .set('Tus-Resumable', TUS_RESUMABLE)
             .end((err) => {
               if (err) {
@@ -314,7 +317,7 @@ describe('Server', () => {
         .set('Upload-Length', Buffer.byteLength('test', 'utf8').toString())
         .then((res) => {
           request(server.listen())
-            .patch(res.headers.location)
+            .patch(removeProtocol(res.headers.location))
             .send('test')
             .set('Tus-Resumable', TUS_RESUMABLE)
             .set('Upload-Offset', '0')
@@ -338,7 +341,7 @@ describe('Server', () => {
         .set('Upload-Defer-Length', '1')
         .then((res) => {
           request(server.listen())
-            .patch(res.headers.location)
+            .patch(removeProtocol(res.headers.location))
             .send('test')
             .set('Tus-Resumable', TUS_RESUMABLE)
             .set('Upload-Offset', '0')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,7 @@ import S3Store from '../lib/stores/S3Store'
 export type ServerOptions = {
   path: string
   relativeLocation?: boolean
+  respectForwardedHeaders?: boolean
   namingFunction?: (req: http.IncomingMessage) => string
 }
 


### PR DESCRIPTION
Closes #256
Closes #134
Closes #59
Closes #170 
Closes #195

- Add new server option: `respectForwardedHeaders`.
- Respect `X-Forwarded-Host` and `X-forwarded-Proto` or `Forwarded` headers.
- Fix bug when `path` is set to root (`/`).