### PR TITLE
Rename File model to Upload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
     "@typescript-eslint/no-empty-function": "off",
     "unicorn/prevent-abbreviations": "off",
     "unicorn/no-null": "off",
-    "unicorn/filename-case": "off"
+    "unicorn/filename-case": "off",
+    "unicorn/explicit-length-check": "off"
   },
   "ignorePatterns": ["demo", "dist", "node_modules"]
 }

--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -14,7 +14,7 @@ import RequestValidator from './validators/RequestValidator'
 import {ERRORS, EXPOSED_HEADERS, REQUEST_METHODS, TUS_RESUMABLE} from './constants'
 
 import type stream from 'node:stream'
-import type {DataStore, ServerOptions, RouteHandler, File} from '../types'
+import type {DataStore, ServerOptions, RouteHandler, Upload} from '../types'
 
 type Handlers = {
   GET: InstanceType<typeof GetHandler>
@@ -25,9 +25,9 @@ type Handlers = {
   DELETE: InstanceType<typeof DeleteHandler>
 }
 interface TusEvents {
-  EVENT_FILE_CREATED: (event: {file: File}) => void
+  EVENT_FILE_CREATED: (event: {file: Upload}) => void
   EVENT_ENDPOINT_CREATED: (event: {url: string}) => void
-  EVENT_UPLOAD_COMPLETE: (event: {file: File}) => void
+  EVENT_UPLOAD_COMPLETE: (event: {file: Upload}) => void
   EVENT_FILE_DELETED: (event: {file_id: string}) => void
 }
 export declare interface Server {

--- a/lib/configstores/MemoryConfigstore.ts
+++ b/lib/configstores/MemoryConfigstore.ts
@@ -1,4 +1,4 @@
-import type {File} from '../../types'
+import type {Upload} from '../../types'
 
 /**
  * Memory based configstore.
@@ -7,13 +7,13 @@ import type {File} from '../../types'
  * @author Mitja Puzigaća <mitjap@gmail.com>
  */
 export default class MemoryConfigstore {
-  data: Map<string, File> = new Map()
+  data: Map<string, Upload> = new Map()
 
-  get(key: string): File | undefined {
+  get(key: string): Upload | undefined {
     return this.data.get(key)
   }
 
-  set(key: string, value: File) {
+  set(key: string, value: Upload) {
     this.data.set(key, value)
   }
 

--- a/lib/handlers/DeleteHandler.ts
+++ b/lib/handlers/DeleteHandler.ts
@@ -5,13 +5,13 @@ import type http from 'node:http'
 
 export default class DeleteHandler extends BaseHandler {
   async send(req: http.IncomingMessage, res: http.ServerResponse) {
-    const file_id = this.getFileIdFromRequest(req)
-    if (file_id === false) {
+    const id = this.getFileIdFromRequest(req)
+    if (id === false) {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    await this.store.remove(file_id)
-    this.emit(EVENTS.EVENT_FILE_DELETED, {file_id})
+    await this.store.remove(id)
+    this.emit(EVENTS.EVENT_FILE_DELETED, {file_id: id})
     return this.write(res, 204, {})
   }
 }

--- a/lib/handlers/GetHandler.ts
+++ b/lib/handlers/GetHandler.ts
@@ -33,22 +33,21 @@ export default class GetHandler extends BaseHandler {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    const file_id = this.getFileIdFromRequest(req)
-    if (file_id === false) {
+    const id = this.getFileIdFromRequest(req)
+    if (id === false) {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    const stats = await this.store.getUpload(file_id)
-    const upload_length = Number.parseInt(stats.upload_length as string, 10)
-    if (stats.size !== upload_length) {
+    const stats = await this.store.getUpload(id)
+    if (stats.offset !== stats.size) {
       log(
-        `[GetHandler] send: File is not yet fully uploaded (${stats.size}/${upload_length})`
+        `[GetHandler] send: File is not yet fully uploaded (${stats.offset}/${stats.size})`
       )
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    const file_stream = this.store.read(file_id)
-    const headers = {'Content-Length': stats.size}
+    const file_stream = this.store.read(id)
+    const headers = {'Content-Length': stats.offset}
     res.writeHead(200, headers)
     return stream.pipeline(file_stream, res, () => {
       // We have no need to handle streaming errors

--- a/lib/handlers/HeadHandler.ts
+++ b/lib/handlers/HeadHandler.ts
@@ -6,35 +6,34 @@ import type http from 'node:http'
 
 export default class HeadHandler extends BaseHandler {
   async send(req: http.IncomingMessage, res: http.ServerResponse) {
-    const file_id = this.getFileIdFromRequest(req)
-    if (file_id === false) {
+    const id = this.getFileIdFromRequest(req)
+    if (id === false) {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    const file = await this.store.getUpload(file_id)
+    const file = await this.store.getUpload(id)
     // The Server MUST prevent the client and/or proxies from
     // caching the response by adding the Cache-Control: no-store
     // header to the response.
     res.setHeader('Cache-Control', 'no-store')
     // The Server MUST always include the Upload-Offset header in
     // the response for a HEAD request, even if the offset is 0
-    res.setHeader('Upload-Offset', file.size?.toString() as string)
-    if (file.upload_length !== undefined) {
+    res.setHeader('Upload-Offset', file.offset)
+
+    if (file.sizeIsDeferred) {
+      // As long as the length of the upload is not known, the Server
+      // MUST set Upload-Defer-Length: 1 in all responses to HEAD requests.
+      res.setHeader('Upload-Defer-Length', '1')
+    } else {
       // If the size of the upload is known, the Server MUST include
       // the Upload-Length header in the response.
-      res.setHeader('Upload-Length', file.upload_length)
+      res.setHeader('Upload-Length', file.size as number)
     }
 
-    if (file.upload_defer_length !== undefined) {
-      //  As long as the length of the upload is not known, the Server
-      //  MUST set Upload-Defer-Length: 1 in all responses to HEAD requests.
-      res.setHeader('Upload-Defer-Length', file.upload_defer_length)
-    }
-
-    if (file.upload_metadata !== undefined) {
+    if (file.metadata !== undefined) {
       // If the size of the upload is known, the Server MUST include
       // the Upload-Length header in the response.
-      res.setHeader('Upload-Metadata', file.upload_metadata)
+      res.setHeader('Upload-Metadata', file.metadata)
     }
 
     return res.end()

--- a/lib/handlers/PatchHandler.ts
+++ b/lib/handlers/PatchHandler.ts
@@ -1,7 +1,6 @@
 import debug from 'debug'
 
 import BaseHandler from './BaseHandler'
-import File from '../models/File'
 import {ERRORS, EVENTS} from '../constants'
 
 import type http from 'node:http'
@@ -13,8 +12,8 @@ export default class PatchHandler extends BaseHandler {
    * Write data to the DataStore and return the new offset.
    */
   async send(req: http.IncomingMessage, res: http.ServerResponse) {
-    const file_id = this.getFileIdFromRequest(req)
-    if (file_id === false) {
+    const id = this.getFileIdFromRequest(req)
+    if (id === false) {
       throw ERRORS.FILE_NOT_FOUND
     }
 
@@ -31,47 +30,41 @@ export default class PatchHandler extends BaseHandler {
       throw ERRORS.INVALID_CONTENT_TYPE
     }
 
-    const file = await this.store.getUpload(file_id)
+    const file = await this.store.getUpload(id)
 
-    if (file.size !== offset) {
+    if (file.offset !== offset) {
       // If the offsets do not match, the Server MUST respond with the 409 Conflict status without modifying the upload resource.
       log(
-        `[PatchHandler] send: Incorrect offset - ${offset} sent but file is ${file.size}`
+        `[PatchHandler] send: Incorrect offset - ${offset} sent but file is ${file.offset}`
       )
       throw ERRORS.INVALID_OFFSET
     }
 
     // The request MUST validate upload-length related headers
-    const upload_length = req.headers['upload-length'] as string
+    const upload_length = req.headers['upload-length'] as string | undefined
     if (upload_length !== undefined) {
+      const size = Number.parseInt(upload_length, 10)
       // Throw error if extension is not supported
       if (!this.store.hasExtension('creation-defer-length')) {
         throw ERRORS.UNSUPPORTED_CREATION_DEFER_LENGTH_EXTENSION
       }
 
       // Throw error if upload-length is already set.
-      if (file.upload_length !== undefined) {
+      if (file.size !== undefined) {
         throw ERRORS.INVALID_LENGTH
       }
 
-      if (Number.parseInt(upload_length, 10) < file.size) {
+      if (size < file.offset) {
         throw ERRORS.INVALID_LENGTH
       }
 
-      await this.store.declareUploadLength(file_id, upload_length)
-      file.upload_length = upload_length
+      await this.store.declareUploadLength(id, size)
+      file.size = size
     }
 
-    const new_offset = await this.store.write(req, file_id, offset)
-    if (new_offset === Number.parseInt(file.upload_length as string, 10)) {
-      this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, {
-        file: new File(
-          file_id,
-          file.upload_length,
-          file.upload_defer_length,
-          file.upload_metadata
-        ),
-      })
+    const new_offset = await this.store.write(req, id, offset)
+    if (new_offset === file.size) {
+      this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, {file})
     }
 
     //  It MUST include the Upload-Offset header containing the new offset.

--- a/lib/handlers/PostHandler.ts
+++ b/lib/handlers/PostHandler.ts
@@ -1,7 +1,7 @@
 import debug from 'debug'
 
 import BaseHandler from './BaseHandler'
-import File from '../models/File'
+import Upload from '../models/Upload'
 import Uid from '../models/Uid'
 import RequestValidator from '../validators/RequestValidator'
 import {EVENTS, ERRORS} from '../constants'
@@ -60,7 +60,7 @@ export default class PostHandler extends BaseHandler {
       throw ERRORS.FILE_WRITE_ERROR
     }
 
-    const file = new File({
+    const file = new Upload({
       id,
       size: upload_length ? Number.parseInt(upload_length, 10) : undefined,
       offset: 0,

--- a/lib/models/File.ts
+++ b/lib/models/File.ts
@@ -1,29 +1,28 @@
-export default class File {
+type Upload = {
   id: string
-  upload_defer_length?: string
-  upload_metadata?: string
-  upload_length?: string
   size?: number
+  offset: number
+  metadata?: string
+}
 
-  constructor(
-    file_id: string,
-    upload_length: string | undefined,
-    upload_defer_length?: string,
-    upload_metadata?: string
-  ) {
-    if (!file_id) {
-      throw new Error('[File] constructor must be given a file_id')
+export default class File {
+  id: Upload['id']
+  metadata?: Upload['metadata']
+  size?: Upload['size']
+  offset: Upload['offset']
+
+  constructor(upload: Upload) {
+    if (!upload.id) {
+      throw new Error('[File] constructor must be given an ID')
     }
 
-    if (upload_length === undefined && upload_defer_length === undefined) {
-      throw new Error(
-        '[File] constructor must be given either a upload_length or upload_defer_length'
-      )
-    }
+    this.id = upload.id
+    this.size = upload.size
+    this.offset = upload.offset
+    this.metadata = upload.metadata
+  }
 
-    this.id = `${file_id}`
-    this.upload_length = upload_length
-    this.upload_defer_length = upload_defer_length
-    this.upload_metadata = upload_metadata
+  get sizeIsDeferred(): boolean {
+    return this.size === undefined
   }
 }

--- a/lib/models/Upload.ts
+++ b/lib/models/Upload.ts
@@ -1,17 +1,17 @@
-type Upload = {
+type TUpload = {
   id: string
   size?: number
   offset: number
   metadata?: string
 }
 
-export default class File {
-  id: Upload['id']
-  metadata?: Upload['metadata']
-  size?: Upload['size']
-  offset: Upload['offset']
+export default class Upload {
+  id: TUpload['id']
+  metadata?: TUpload['metadata']
+  size?: TUpload['size']
+  offset: TUpload['offset']
 
-  constructor(upload: Upload) {
+  constructor(upload: TUpload) {
     if (!upload.id) {
       throw new Error('[File] constructor must be given an ID')
     }

--- a/lib/stores/DataStore.ts
+++ b/lib/stores/DataStore.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import EventEmitter from 'node:events'
 
+import File from '../models/File'
+
 import type stream from 'node:stream'
 import type http from 'node:http'
-import type {File} from '../../types'
 
 export default class DataStore extends EventEmitter {
   private _extensions: string[] = []
@@ -38,7 +39,7 @@ export default class DataStore extends EventEmitter {
    * Called in DELETE requests. This method just deletes the file from the store.
    * http://tus.io/protocols/resumable-upload.html#termination
    */
-  async remove(file_id: string) {}
+  async remove(id: string) {}
 
   /**
    * Called in PATCH requests. This method should write data
@@ -49,7 +50,7 @@ export default class DataStore extends EventEmitter {
    */
   async write(
     stream: http.IncomingMessage | stream.Readable,
-    file_id: string,
+    id: string,
     offset: number
   ) {
     return 0
@@ -60,12 +61,12 @@ export default class DataStore extends EventEmitter {
    * writen to the DataStore, for the client to know where to resume
    * the upload.
    */
-  async getUpload(file_id: string): Promise<File> {
-    return {id: file_id, size: 0, upload_length: '0'}
+  async getUpload(id: string): Promise<File> {
+    return new File({id, size: 0, offset: 0})
   }
 
   /**
    * Called in PATCH requests when upload length is known after being defered.
    */
-  async declareUploadLength(file_id: string, upload_length: string) {}
+  async declareUploadLength(id: string, upload_length: number) {}
 }

--- a/lib/stores/DataStore.ts
+++ b/lib/stores/DataStore.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import EventEmitter from 'node:events'
 
-import File from '../models/File'
+import Upload from '../models/Upload'
 
 import type stream from 'node:stream'
 import type http from 'node:http'
@@ -31,7 +31,7 @@ export default class DataStore extends EventEmitter {
    *
    * http://tus.io/protocols/resumable-upload.html#creation
    */
-  async create(file: File) {
+  async create(file: Upload) {
     return file
   }
 
@@ -61,8 +61,8 @@ export default class DataStore extends EventEmitter {
    * writen to the DataStore, for the client to know where to resume
    * the upload.
    */
-  async getUpload(id: string): Promise<File> {
-    return new File({id, size: 0, offset: 0})
+  async getUpload(id: string): Promise<Upload> {
+    return new Upload({id, size: 0, offset: 0})
   }
 
   /**

--- a/lib/stores/FileStore.ts
+++ b/lib/stores/FileStore.ts
@@ -11,11 +11,11 @@ import DataStore from './DataStore'
 import pkg from '../../package.json'
 import {ERRORS} from '../constants'
 
-import File from '../models/File'
+import Upload from '../models/Upload'
 
 type Store = {
-  get(key: string): File | undefined
-  set(key: string, value: File): void
+  get(key: string): Upload | undefined
+  set(key: string, value: Upload): void
   delete(key: string): void
 }
 
@@ -61,7 +61,7 @@ export default class FileStore extends DataStore {
   /**
    * Create an empty file.
    */
-  create(file: File): Promise<File> {
+  create(file: Upload): Promise<Upload> {
     return new Promise((resolve, reject) => {
       fs.open(path.join(this.directory, file.id), 'w', (err, fd) => {
         if (err) {
@@ -139,7 +139,7 @@ export default class FileStore extends DataStore {
     })
   }
 
-  async getUpload(id: string): Promise<File> {
+  async getUpload(id: string): Promise<Upload> {
     const file = this.configstore.get(id)
 
     if (!file) {
@@ -172,7 +172,7 @@ export default class FileStore extends DataStore {
         }
 
         return resolve(
-          new File({id, size: file.size, offset: stats.size, metadata: file.metadata})
+          new Upload({id, size: file.size, offset: stats.size, metadata: file.metadata})
         )
       })
     })

--- a/lib/stores/GCSDataStore.ts
+++ b/lib/stores/GCSDataStore.ts
@@ -5,8 +5,7 @@ import debug from 'debug'
 
 import {ERRORS, TUS_RESUMABLE} from '../constants'
 import DataStore from './DataStore'
-
-import type {File} from '../../types'
+import File from '../models/File'
 
 type Options = {
   bucket: string
@@ -73,9 +72,10 @@ export default class GCSDataStore extends DataStore {
         metadata: {
           metadata: {
             tus_version: TUS_RESUMABLE,
-            upload_length: file.upload_length,
-            upload_metadata: file.upload_metadata,
-            upload_defer_length: file.upload_defer_length,
+            size: file.size,
+            sizeIsDeferred: `${file.sizeIsDeferred}`,
+            offset: file.offset,
+            metadata: file.metadata,
           },
         },
       }
@@ -100,23 +100,24 @@ export default class GCSDataStore extends DataStore {
    */
   write(
     readable: http.IncomingMessage | stream.Readable,
-    file_id: string,
+    id: string,
     offset: number
   ): Promise<number> {
     // GCS Doesn't persist metadata within versions,
     // get that metadata first
-    return this.getUpload(file_id).then((data) => {
+    return this.getUpload(id).then((upload) => {
       return new Promise((resolve, reject) => {
-        const file = this.bucket.file(file_id)
-        const destination = data.size === 0 ? file : this.bucket.file(`${file_id}_patch`)
+        const file = this.bucket.file(id)
+        const destination = upload.offset === 0 ? file : this.bucket.file(`${id}_patch`)
         const options = {
           offset,
           metadata: {
             metadata: {
-              upload_length: data.upload_length,
               tus_version: TUS_RESUMABLE,
-              upload_metadata: data.upload_metadata,
-              upload_defer_length: data.upload_defer_length,
+              size: upload.size,
+              sizeIsDeferred: `${upload.sizeIsDeferred}`,
+              offset,
+              metadata: upload.metadata,
             },
           },
         }
@@ -126,7 +127,7 @@ export default class GCSDataStore extends DataStore {
           return
         }
 
-        let bytes_received = data.size as number
+        let bytes_received = upload.offset
         readable.on('data', (buffer) => {
           bytes_received += buffer.length
         })
@@ -160,15 +161,15 @@ export default class GCSDataStore extends DataStore {
     })
   }
 
-  getUpload(file_id: string): Promise<File> {
+  getUpload(id: string): Promise<File> {
     return new Promise((resolve, reject) => {
-      if (!file_id) {
+      if (!id) {
         reject(ERRORS.FILE_NOT_FOUND)
         return
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      this.bucket.file(file_id).getMetadata((error: any, metadata: any) => {
+      this.bucket.file(id).getMetadata((error: any, metadata: any) => {
         if (error && error.code === 404) {
           return reject(ERRORS.FILE_NOT_FOUND)
         }
@@ -178,38 +179,24 @@ export default class GCSDataStore extends DataStore {
           return reject(error)
         }
 
-        const data: File = {
-          id: file_id,
-          size: Number.parseInt(metadata.size, 10),
-        }
-        if (!('metadata' in metadata)) {
-          return resolve(data)
-        }
-
-        if (metadata.metadata.upload_length) {
-          data.upload_length = metadata.metadata.upload_length
-        }
-
-        if (metadata.metadata.upload_defer_length) {
-          data.upload_defer_length = metadata.metadata.upload_defer_length
-        }
-
-        if (metadata.metadata.upload_metadata) {
-          data.upload_metadata = metadata.metadata.upload_metadata
-        }
-
-        return resolve(data)
+        const {size, metadata: meta} = metadata.metadata
+        return resolve(
+          new File({
+            id,
+            size: size ? Number.parseInt(size, 10) : size,
+            offset: Number.parseInt(metadata.size, 10), // `size` is set by GCS
+            metadata: meta,
+          })
+        )
       })
     })
   }
 
-  async declareUploadLength(file_id: string, upload_length: string) {
-    const metadata = await this.getUpload(file_id)
-    metadata.upload_length = upload_length
-    // NOTE: this needs to be `null` and not `undefined`,
-    // GCS has logic that if it's the latter, it will keep the previous value ¯\_(ツ)_/¯
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    metadata.upload_defer_length = null!
-    await this.bucket.file(file_id).setMetadata({metadata})
+  async declareUploadLength(id: string, upload_length: number) {
+    const upload = await this.getUpload(id)
+
+    upload.size = upload_length
+
+    await this.bucket.file(id).setMetadata({metadata: upload})
   }
 }

--- a/lib/stores/GCSDataStore.ts
+++ b/lib/stores/GCSDataStore.ts
@@ -5,7 +5,7 @@ import debug from 'debug'
 
 import {ERRORS, TUS_RESUMABLE} from '../constants'
 import DataStore from './DataStore'
-import File from '../models/File'
+import Upload from '../models/Upload'
 
 type Options = {
   bucket: string
@@ -60,7 +60,7 @@ export default class GCSDataStore extends DataStore {
     return bucket
   }
 
-  create(file: File): Promise<File> {
+  create(file: Upload): Promise<Upload> {
     return new Promise((resolve, reject) => {
       if (!file.id) {
         reject(ERRORS.FILE_NOT_FOUND)
@@ -161,7 +161,7 @@ export default class GCSDataStore extends DataStore {
     })
   }
 
-  getUpload(id: string): Promise<File> {
+  getUpload(id: string): Promise<Upload> {
     return new Promise((resolve, reject) => {
       if (!id) {
         reject(ERRORS.FILE_NOT_FOUND)
@@ -181,7 +181,7 @@ export default class GCSDataStore extends DataStore {
 
         const {size, metadata: meta} = metadata.metadata
         return resolve(
-          new File({
+          new Upload({
             id,
             size: size ? Number.parseInt(size, 10) : size,
             offset: Number.parseInt(metadata.size, 10), // `size` is set by GCS

--- a/lib/stores/S3Store.ts
+++ b/lib/stores/S3Store.ts
@@ -6,13 +6,12 @@ import stream from 'node:stream'
 import http from 'node:http'
 
 import aws from 'aws-sdk'
+import debug from 'debug'
 
 import DataStore from './DataStore'
 import FileStreamSplitter from '../models/StreamSplitter'
+import File from '../models/File'
 import {ERRORS, TUS_RESUMABLE} from '../constants'
-
-import debug from 'debug'
-import {File} from '../../types'
 
 const log = debug('tus-node-server:stores:s3store')
 
@@ -58,7 +57,7 @@ type MetadataValue = {file: File; upload_id: string}
 // are internally used.
 // For each incoming PATCH request (a call to `write`), a new part is uploaded
 // to S3.
-class S3Store extends DataStore {
+export default class S3Store extends DataStore {
   bucket_name: string
   // TODO: is a `WeakMap` better here?
   cache: Map<string, MetadataValue> = new Map()
@@ -110,7 +109,7 @@ class S3Store extends DataStore {
    */
   _initMultipartUpload(file: File) {
     log(`[${file.id}] initializing multipart upload`)
-    const parsedMetadata = this._parseMetadataString(file.upload_metadata)
+    const parsedMetadata = this._parseMetadataString(file.metadata)
     type Data = {
       Bucket: string
       Key: string
@@ -118,9 +117,10 @@ class S3Store extends DataStore {
       Metadata: {
         tus_version: string
         original_name?: string
-        upload_length?: string
-        upload_defer_length?: string
-        upload_metadata?: string
+        size?: string
+        isSizeDeferred?: string
+        offset: string
+        metadata?: string
       }
     }
     const upload_data: Data = {
@@ -128,18 +128,18 @@ class S3Store extends DataStore {
       Key: file.id,
       Metadata: {
         tus_version: TUS_RESUMABLE,
+        offset: file.offset.toString(),
       },
     }
-    if (file.upload_length !== undefined) {
-      upload_data.Metadata.upload_length = file.upload_length
+    if (file.size) {
+      upload_data.Metadata.size = file.size.toString()
+      upload_data.Metadata.isSizeDeferred = 'false'
+    } else {
+      upload_data.Metadata.isSizeDeferred = 'true'
     }
 
-    if (file.upload_defer_length !== undefined) {
-      upload_data.Metadata.upload_defer_length = file.upload_defer_length
-    }
-
-    if (file.upload_metadata !== undefined) {
-      upload_data.Metadata.upload_metadata = file.upload_metadata
+    if (file.metadata !== undefined) {
+      upload_data.Metadata.metadata = file.metadata
     }
 
     if (parsedMetadata.contentType) {
@@ -203,30 +203,36 @@ class S3Store extends DataStore {
    * There's a small and simple caching mechanism to avoid multiple
    * HTTP calls to S3.
    */
-  _getMetadata(file_id: string): Promise<MetadataValue> {
-    log(`[${file_id}] retrieving metadata`)
-    const cached = this.cache.get(file_id)
+  _getMetadata(id: string): Promise<MetadataValue> {
+    log(`[${id}] retrieving metadata`)
+    const cached = this.cache.get(id)
     if (cached?.file) {
-      log(`[${file_id}] metadata from cache`)
+      log(`[${id}] metadata from cache`)
       return Promise.resolve(cached)
     }
 
-    log(`[${file_id}] metadata from s3`)
+    log(`[${id}] metadata from s3`)
     return this.client
       .headObject({
         Bucket: this.bucket_name,
-        Key: `${file_id}.info`,
+        Key: `${id}.info`,
       })
       .promise()
       .then(({Metadata}) => {
-        this.cache.set(file_id, {
+        const file = JSON.parse(Metadata?.file as string)
+        this.cache.set(id, {
           ...Metadata,
-          file: JSON.parse(Metadata?.file as string),
+          file: new File({
+            id,
+            size: file.size ? Number.parseInt(file.size, 10) : undefined,
+            offset: Number.parseInt(file.offset, 10),
+            metadata: file.metadata,
+          }),
           // Patch for Digital Ocean: if key upload_id (AWS, standard) doesn't exist in Metadata object, fallback to upload-id (DO)
           upload_id:
             (Metadata?.upload_id as string) || (Metadata?.['upload-id'] as string),
         })
-        return this.cache.get(file_id) as MetadataValue
+        return this.cache.get(id) as MetadataValue
       })
       .catch((error) => {
         throw error
@@ -315,8 +321,7 @@ class S3Store extends DataStore {
         const p = Promise.resolve()
           .then(() => {
             // Skip chunk if it is not last and is smaller than 5MB
-            const is_last_chunk =
-              Number.parseInt(metadata?.file?.upload_length ?? '', 10) === current_size
+            const is_last_chunk = metadata.file.size === current_size
             if (!is_last_chunk && size < 5 * 1024 * 1024) {
               log(`[${metadata.file.id}] ignoring chuck smaller than 5MB`)
               return
@@ -367,13 +372,13 @@ class S3Store extends DataStore {
    * Retrieves only consecutive parts.
    */
   _retrieveParts(
-    file_id: string,
+    id: string,
     part_number_marker?: number
   ): Promise<aws.S3.Parts | undefined> {
     const params: aws.S3.ListPartsRequest = {
       Bucket: this.bucket_name,
-      Key: file_id,
-      UploadId: this.cache.get(file_id)?.upload_id as string,
+      Key: id,
+      UploadId: this.cache.get(id)?.upload_id as string,
     }
     if (part_number_marker) {
       params.PartNumberMarker = part_number_marker
@@ -384,7 +389,7 @@ class S3Store extends DataStore {
       .promise()
       .then((data) => {
         if (data.NextPartNumberMarker) {
-          return this._retrieveParts(file_id, data.NextPartNumberMarker).then((parts) => {
+          return this._retrieveParts(id, data.NextPartNumberMarker).then((parts) => {
             return [...(data.Parts as aws.S3.Parts), ...(parts as aws.S3.Parts)]
           })
         }
@@ -445,29 +450,18 @@ class S3Store extends DataStore {
         return Promise.all([metadata, this._countParts(file_id), this.getUpload(file_id)])
       })
       .then(async (results) => {
-        const [metadata, part_number, initial_offset] = results
+        const [metadata, part_number, upload] = results
         const next_part_number = part_number + 1
         return Promise.all(
-          await this._processUpload(
-            metadata,
-            readable,
-            next_part_number,
-            initial_offset.size
-          )
+          await this._processUpload(metadata, readable, next_part_number, upload.offset)
         )
           .then(() => this.getUpload(file_id))
-          .then((current_offset) => {
-            if (
-              Number.parseInt(metadata.file.upload_length as string, 10) ===
-              current_offset.size
-            ) {
-              return this._finishMultipartUpload(
-                metadata,
-                current_offset.parts as aws.S3.Parts
-              )
+          .then((upload) => {
+            if (metadata.file.size === upload.offset) {
+              return this._finishMultipartUpload(metadata, upload.parts as aws.S3.Parts)
                 .then(() => {
                   this._clearCache(file_id)
-                  return current_offset.size
+                  return upload.offset
                 })
                 .catch((error) => {
                   log(`[${file_id}] failed to finish upload`, error)
@@ -475,7 +469,7 @@ class S3Store extends DataStore {
                 })
             }
 
-            return current_offset.size
+            return upload.offset
           })
           .catch((error) => {
             if (['RequestTimeout', 'NoSuchUpload'].includes(error.code)) {
@@ -491,7 +485,9 @@ class S3Store extends DataStore {
                 )
               }
 
-              return this.getUpload(file_id).then((current_offset) => current_offset.size)
+              return this.getUpload(file_id).then(
+                (current_offset) => current_offset.offset
+              )
             }
 
             this._clearCache(file_id)
@@ -501,8 +497,9 @@ class S3Store extends DataStore {
       })
   }
 
-  async getUpload(id: string): Promise<File & {parts?: aws.S3.Parts; size: number}> {
-    let metadata: MetadataValue | undefined
+  // TODO: getUpload should only return file
+  async getUpload(id: string): Promise<File & {parts?: aws.S3.Parts}> {
+    let metadata: MetadataValue
     try {
       metadata = await this._getMetadata(id)
     } catch (error) {
@@ -516,9 +513,9 @@ class S3Store extends DataStore {
         id,
         ...this.cache.get(id)?.file,
         // @ts-expect-error object is not possibly undefined
-        size: parts && parts.length > 0 ? parts.reduce((a, b) => a + b.Size, 0) : 0,
-        upload_length: metadata?.file.upload_length,
-        upload_defer_length: metadata?.file.upload_defer_length,
+        offset: parts && parts.length > 0 ? parts.reduce((a, b) => a + b.Size, 0) : 0,
+        size: metadata.file.size,
+        sizeIsDeferred: metadata.file.sizeIsDeferred,
         parts,
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -534,22 +531,21 @@ class S3Store extends DataStore {
       return {
         id,
         ...this.cache.get(id)?.file,
-        size: Number.parseInt(metadata.file.upload_length as string, 10),
-        upload_length: metadata.file.upload_length,
-        upload_defer_length: metadata.file.upload_defer_length,
+        offset: metadata.file.offset,
+        size: metadata.file.size,
+        sizeIsDeferred: metadata.file.sizeIsDeferred,
       }
     }
   }
 
-  async declareUploadLength(file_id: string, upload_length: string) {
+  async declareUploadLength(file_id: string, upload_length: number) {
     const {file, upload_id} = await this._getMetadata(file_id)
     if (!file) {
       throw ERRORS.FILE_NOT_FOUND
     }
 
-    file.upload_length = upload_length
-    file.upload_defer_length = undefined
+    file.size = upload_length
+
     this._saveMetadata(file, upload_id)
   }
 }
-export default S3Store

--- a/test/Test-File.ts
+++ b/test/Test-File.ts
@@ -13,23 +13,17 @@ describe('File', () => {
       }, Error)
     })
 
-    it('must be given either a upload_length or upload_defer_length', () => {
-      assert.throws(() => {
-        // @ts-expect-error TS(2554): Expected 4 arguments, but got 1.
-        new File(Uid.rand())
-      }, Error)
-    })
-
     it('should set properties given', () => {
-      const file_id = Uid.rand()
-      const upload_length = '1234'
-      const upload_defer_length = '1'
-      const upload_metadata = 'metadata'
-      const file = new File(file_id, upload_length, upload_defer_length, upload_metadata)
-      assert.equal(file.id, file_id)
-      assert.equal(file.upload_length, upload_length)
-      assert.equal(file.upload_defer_length, upload_defer_length)
-      assert.equal(file.upload_metadata, upload_metadata)
+      const id = Uid.rand()
+      const size = 1234
+      const offset = 0
+      const metadata = 'metadata'
+      const file = new File({id, size, offset, metadata})
+      assert.equal(file.id, id)
+      assert.equal(file.size, size)
+      assert.equal(file.offset, offset)
+      assert.equal(file.sizeIsDeferred, false)
+      assert.equal(file.metadata, metadata)
     })
   })
 })

--- a/test/Test-File.ts
+++ b/test/Test-File.ts
@@ -1,7 +1,7 @@
 import 'should'
 import {strict as assert} from 'node:assert'
 
-import File from '../lib/models/File'
+import File from '../lib/models/Upload'
 import Uid from '../lib/models/Uid'
 
 describe('File', () => {

--- a/test/Test-FileStore.ts
+++ b/test/Test-FileStore.ts
@@ -8,7 +8,7 @@ import sinon from 'sinon'
 
 import FileStore from '../lib/stores/FileStore'
 import MemoryConfigstore from '../lib/configstores/MemoryConfigstore'
-import File from '../lib/models/File'
+import Upload from '../lib/models/Upload'
 
 import * as shared from './Test-Stores.shared'
 
@@ -43,7 +43,7 @@ describe('FileStore', function () {
   })
 
   describe('create', () => {
-    const file = new File({id: '1234', size: 1000, offset: 0})
+    const file = new Upload({id: '1234', size: 1000, offset: 0})
 
     it('should reject when the directory doesnt exist', function () {
       this.datastore.directory = 'some_new_path'
@@ -64,7 +64,7 @@ describe('FileStore', function () {
   })
 
   describe('write', function () {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       // @ts-expect-error todo
       size: this.testFileSize,

--- a/test/Test-FileStore.ts
+++ b/test/Test-FileStore.ts
@@ -43,7 +43,7 @@ describe('FileStore', function () {
   })
 
   describe('create', () => {
-    const file = new File('1234', '1000')
+    const file = new File({id: '1234', size: 1000, offset: 0})
 
     it('should reject when the directory doesnt exist', function () {
       this.datastore.directory = 'some_new_path'
@@ -64,13 +64,13 @@ describe('FileStore', function () {
   })
 
   describe('write', function () {
-    const file = new File(
-      '1234',
-      // @ts-expect-error this not typed
-      `${this.testFileSize}`,
-      undefined,
-      'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential'
-    )
+    const file = new File({
+      id: '1234',
+      // @ts-expect-error todo
+      size: this.testFileSize,
+      offset: 0,
+      metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
+    })
 
     it("created file's size should match 'upload_length'", async function () {
       await this.datastore.create(file)

--- a/test/Test-GetHandler.ts
+++ b/test/Test-GetHandler.ts
@@ -11,7 +11,7 @@ import sinon from 'sinon'
 import GetHandler from '../lib/handlers/GetHandler'
 import DataStore from '../lib/stores/DataStore'
 import FileStore from '../lib/stores/FileStore'
-import File from '../lib/models/File'
+import File from '../lib/models/Upload'
 
 describe('GetHandler', () => {
   const path = '/test/output'

--- a/test/Test-HeadHandler.ts
+++ b/test/Test-HeadHandler.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon'
 import DataStore from '../lib/stores/DataStore'
 import HeadHandler from '../lib/handlers/HeadHandler'
 import {ERRORS} from '../lib/constants'
-import File from '../lib/models/File'
+import Upload from '../lib/models/Upload'
 
 describe('HeadHandler', () => {
   const path = '/test/output'
@@ -34,7 +34,7 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve with the offset and cache-control', async () => {
-    fake_store.getUpload.resolves(new File({id: '1234', offset: 0}))
+    fake_store.getUpload.resolves(new Upload({id: '1234', offset: 0}))
     await handler.send(req, res)
     assert.equal(res.getHeader('Upload-Offset'), 0)
     assert.equal(res.getHeader('Cache-Control'), 'no-store')
@@ -42,7 +42,7 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve with upload-length', async () => {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       offset: 0,
       size: 512,
@@ -55,7 +55,7 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve with upload-defer-length', async () => {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       offset: 0,
       metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
@@ -67,7 +67,7 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve with metadata', async () => {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       offset: 0,
       metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
@@ -78,7 +78,7 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve without metadata', async () => {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       offset: 0,
     })

--- a/test/Test-HeadHandler.ts
+++ b/test/Test-HeadHandler.ts
@@ -7,6 +7,7 @@ import sinon from 'sinon'
 import DataStore from '../lib/stores/DataStore'
 import HeadHandler from '../lib/handlers/HeadHandler'
 import {ERRORS} from '../lib/constants'
+import File from '../lib/models/File'
 
 describe('HeadHandler', () => {
   const path = '/test/output'
@@ -33,53 +34,54 @@ describe('HeadHandler', () => {
   })
 
   it('should resolve with the offset and cache-control', async () => {
-    fake_store.getUpload.resolves({id: '1234', size: 0, upload_length: '1'})
+    fake_store.getUpload.resolves(new File({id: '1234', offset: 0}))
     await handler.send(req, res)
-    assert.equal(res.getHeader('Upload-Offset'), '0')
+    assert.equal(res.getHeader('Upload-Offset'), 0)
     assert.equal(res.getHeader('Cache-Control'), 'no-store')
     assert.equal(res.statusCode, 200)
   })
 
   it('should resolve with upload-length', async () => {
-    const file = {
+    const file = new File({
       id: '1234',
-      size: 0,
-      upload_length: '1',
-      upload_metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
-    }
+      offset: 0,
+      size: 512,
+      metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
+    })
     fake_store.getUpload.resolves(file)
     await handler.send(req, res)
-    assert.equal(res.getHeader('Upload-Length'), file.upload_length)
+    assert.equal(res.getHeader('Upload-Length'), file.size)
     assert.equal(res.hasHeader('Upload-Defer-Length'), false)
   })
 
   it('should resolve with upload-defer-length', async () => {
-    const file = {
+    const file = new File({
       id: '1234',
-      size: 0,
-      upload_defer_length: '1',
-      upload_metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
-    }
+      offset: 0,
+      metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
+    })
     fake_store.getUpload.resolves(file)
     await handler.send(req, res)
-    assert.equal(res.getHeader('Upload-Defer-Length'), file.upload_defer_length)
+    assert.equal(res.getHeader('Upload-Defer-Length'), '1')
     assert.equal(res.hasHeader('Upload-Length'), false)
   })
 
   it('should resolve with metadata', async () => {
-    const file = {
+    const file = new File({
       id: '1234',
-      size: 0,
-      upload_length: '1',
-      upload_metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
-    }
+      offset: 0,
+      metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
+    })
     fake_store.getUpload.resolves(file)
     await handler.send(req, res)
-    assert.equal(res.getHeader('Upload-Metadata'), file.upload_metadata)
+    assert.equal(res.getHeader('Upload-Metadata'), file.metadata)
   })
 
   it('should resolve without metadata', async () => {
-    const file = {id: '1234', size: 0, upload_length: '1'}
+    const file = new File({
+      id: '1234',
+      offset: 0,
+    })
     fake_store.getUpload.resolves(file)
     await handler.send(req, res)
     assert.equal(res.hasHeader('Upload-Metadata'), false)

--- a/test/Test-PatchHandler.ts
+++ b/test/Test-PatchHandler.ts
@@ -7,6 +7,7 @@ import net from 'node:net'
 import sinon from 'sinon'
 import PatchHandler from '../lib/handlers/PatchHandler'
 import DataStore from '../lib/stores/DataStore'
+import File from '../lib/models/File'
 
 describe('PatchHandler', () => {
   const path = '/test/output'
@@ -64,13 +65,13 @@ describe('PatchHandler', () => {
       req.url = `${path}/file`
 
       store.hasExtension.withArgs('creation-defer-length').returns(true)
-      store.getUpload.resolves({id: '1234', size: 0, upload_defer_length: '1'})
+      store.getUpload.resolves(new File({id: '1234', offset: 0}))
       store.write.resolves(5)
       store.declareUploadLength.resolves()
 
       await handler.send(req, res)
 
-      assert.equal(store.declareUploadLength.calledOnceWith('file', '10'), true)
+      assert.equal(store.declareUploadLength.calledOnceWith('file', 10), true)
     })
 
     it('should 400 if upload-length is already set', () => {
@@ -81,7 +82,7 @@ describe('PatchHandler', () => {
       }
       req.url = `${path}/file`
 
-      store.getUpload.resolves({id: '1234', size: 0, upload_length: '20'})
+      store.getUpload.resolves(new File({id: '1234', offset: 0, size: 20}))
       store.hasExtension.withArgs('creation-defer-length').returns(true)
 
       return assert.rejects(() => handler.send(req, res), {status_code: 400})
@@ -106,7 +107,7 @@ describe('PatchHandler', () => {
       }
       req.url = `${path}/1234`
 
-      store.getUpload.resolves({id: '1234', size: 0, upload_length: '512'})
+      store.getUpload.resolves(new File({id: '1234', offset: 0, size: 512}))
 
       return assert.rejects(() => handler.send(req, res), {status_code: 409})
     })
@@ -118,7 +119,7 @@ describe('PatchHandler', () => {
       }
       req.url = `${path}/1234`
 
-      store.getUpload.resolves({id: '1234', size: 0, upload_length: '1024'})
+      store.getUpload.resolves(new File({id: '1234', offset: 0, size: 1024}))
       store.write.resolves(10)
 
       await handler.send(req, res)

--- a/test/Test-PatchHandler.ts
+++ b/test/Test-PatchHandler.ts
@@ -7,7 +7,7 @@ import net from 'node:net'
 import sinon from 'sinon'
 import PatchHandler from '../lib/handlers/PatchHandler'
 import DataStore from '../lib/stores/DataStore'
-import File from '../lib/models/File'
+import File from '../lib/models/Upload'
 
 describe('PatchHandler', () => {
   const path = '/test/output'

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -117,7 +117,7 @@ describe('PostHandler', () => {
       it(`must fire the ${EVENTS.EVENT_FILE_CREATED} event`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)
 
-        const file = new File('1234', '10')
+        const file = new File({id: '1234', size: 10, offset: 0})
         fake_store.create.resolves(file)
 
         const handler = new PostHandler(fake_store, SERVER_OPTIONS)
@@ -133,7 +133,7 @@ describe('PostHandler', () => {
       it(`must fire the ${EVENTS.EVENT_ENDPOINT_CREATED} event with absolute URL`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)
 
-        const file = new File('1234', '10')
+        const file = new File({id: '1234', size: 10, offset: 0})
         fake_store.create.resolves(file)
 
         const handler = new PostHandler(fake_store, {
@@ -152,7 +152,7 @@ describe('PostHandler', () => {
       it(`must fire the ${EVENTS.EVENT_ENDPOINT_CREATED} event with relative URL`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)
 
-        const file = new File('1234', '10')
+        const file = new File({id: '1234', size: 10, offset: 0})
         fake_store.create.resolves(file)
 
         const handler = new PostHandler(fake_store, {

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -10,7 +10,7 @@ import sinon from 'sinon'
 import DataStore from '../lib/stores/DataStore'
 import PostHandler from '../lib/handlers/PostHandler'
 import {EVENTS} from '../lib/constants'
-import File from '../lib/models/File'
+import File from '../lib/models/Upload'
 
 const SERVER_OPTIONS = {
   path: '/test',

--- a/test/Test-Stores.shared.ts
+++ b/test/Test-Stores.shared.ts
@@ -3,7 +3,7 @@ import {strict as assert} from 'node:assert'
 import fs from 'node:fs'
 import stream from 'node:stream'
 
-import File from '../lib/models/File'
+import Upload from '../lib/models/Upload'
 
 export const shouldHaveStoreMethods = function () {
   describe('the class', () => {
@@ -21,20 +21,20 @@ export const shouldHaveStoreMethods = function () {
 
 export const shouldCreateUploads = function () {
   describe('create', () => {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       size: 1000,
       offset: 0,
       metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',
     })
-    const file_defered = new File({
+    const file_defered = new Upload({
       id: '1234',
       offset: 0,
     })
 
     it('should resolve to file', async function () {
       const newFile = await this.datastore.create(file)
-      assert.equal(newFile instanceof File, true)
+      assert.equal(newFile instanceof Upload, true)
     })
 
     it("should report 'creation' extension", function () {
@@ -68,7 +68,7 @@ export const shouldCreateUploads = function () {
 }
 
 export const shouldRemoveUploads = function () {
-  const file = new File({id: '1234', size: 1000, offset: 0})
+  const file = new Upload({id: '1234', size: 1000, offset: 0})
 
   describe('remove (termination extension)', () => {
     it("should report 'termination' extension", function () {
@@ -99,7 +99,7 @@ export const shouldWriteUploads = function () {
     })
 
     it('should write a stream and resolve the new offset', async function () {
-      const file = new File({
+      const file = new Upload({
         id: '1234',
         size: this.testFileSize,
         offset: 0,
@@ -112,7 +112,7 @@ export const shouldWriteUploads = function () {
     })
 
     it('should reject when stream is destroyed', async function () {
-      const file = new File({
+      const file = new Upload({
         id: '1234',
         size: this.testFileSize,
         offset: 0,
@@ -133,7 +133,7 @@ export const shouldWriteUploads = function () {
 
 export const shouldHandleOffset = function () {
   describe('getUpload', function () {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       // @ts-expect-error todo
       size: this.testFileSize,
@@ -160,7 +160,7 @@ export const shouldHandleOffset = function () {
 
 export const shouldDeclareUploadLength = function () {
   describe('declareUploadLength', () => {
-    const file = new File({
+    const file = new Upload({
       id: '1234',
       offset: 0,
       metadata: 'filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,is_confidential',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import type http from 'node:http'
-import FileModel from '../lib/models/File'
+import UploadModel from '../lib/models/Upload'
 
 import BaseStore from '../lib/stores/DataStore'
 import FileStore from '../lib/stores/FileStore'
@@ -12,7 +12,7 @@ export type ServerOptions = {
   namingFunction?: (req: http.IncomingMessage) => string
 }
 
-export type File = InstanceType<typeof FileModel>
+export type Upload = InstanceType<typeof UploadModel>
 
 export type DataStore =
   | InstanceType<typeof BaseStore>


### PR DESCRIPTION
- Rename `size` to `offset` and make the type non-optional
- Rename `upload_length` to `size`
- Create `sizeIsDeferred` getter
- Rename `upload_metadata` to `metadata`

### Questions
- Should we rename `File` to `Upload` since we recently renamed the method that returns it to `getUpload`?