### PR TITLE
Clean up `S3Store`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "outDir": "dist",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "useUnknownInCatchVariables": false
   },
   "ts-node": {
     "transpileOnly": true


### PR DESCRIPTION
Clean up in preparation for upcoming S3 store changes.

- Use `async`/`await`
- Improve types
- Simplify `write` and de-dupe network calls.
- Make `getUpload` consistent with other stores (no longer returning `parts`)