### PR TITLE
S3Store: calculate optimal part size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: ['master', '1.x']
   pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - .github/workflows/ci.yml
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 concurrency: ${{ github.workflow }}--${{ github.ref }}

--- a/lib/models/StreamSplitter.ts
+++ b/lib/models/StreamSplitter.ts
@@ -1,5 +1,6 @@
+/* global BufferEncoding */
 import crypto from 'node:crypto'
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import stream from 'node:stream'
 
@@ -8,132 +9,107 @@ function randomString(size: number) {
 }
 
 type Options = {
-  maxChunkSize: number
+  chunkSize: number
   directory: string
 }
+
+type Callback = (error: Error | null) => void
 
 export default class FileStreamSplitter extends stream.Writable {
   directory: Options['directory']
   currentChunkPath: string | null
-  currentChunkSize: number | null
-  fileDescriptor: number | null
+  currentChunkSize: number
+  fileHandle: fs.FileHandle | null
   filenameTemplate: string
-  maxChunkSize: Options['maxChunkSize']
+  chunkSize: Options['chunkSize']
   part: number
 
-  constructor({maxChunkSize, directory}: Options, options?: stream.WritableOptions) {
+  constructor({chunkSize, directory}: Options, options?: stream.WritableOptions) {
     super(options)
-    this.maxChunkSize = maxChunkSize
+    this.chunkSize = chunkSize
     this.currentChunkPath = null
-    this.currentChunkSize = null
-    this.fileDescriptor = null
+    this.currentChunkSize = 0
+    this.fileHandle = null
     this.directory = directory
     this.filenameTemplate = randomString(10)
     this.part = 0
     this.on('error', this._finishChunk.bind(this))
   }
 
-  _write(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    chunk: any,
-    _: globalThis.BufferEncoding,
-    callback: (error: Error | null) => void
-  ) {
-    Promise.resolve()
-      .then(() => {
-        // In order to start writing a chunk, we must first create
-        // a file system reference for it
-        if (this.fileDescriptor === null) {
-          return this._newChunk()
-        }
-      })
-      .then(() => {
-        const overflow = this.currentChunkSize + chunk.length - this.maxChunkSize
-        // If the chunk is bigger than the defined max chunk size,
-        // we need two passes to process the chunk
-        if (overflow > 0) {
-          return this._writeChunk(chunk.slice(0, chunk.length - overflow))
-            .then(this._finishChunk.bind(this))
-            .then(this._newChunk.bind(this))
-            .then(() => {
-              return this._writeChunk(chunk.slice(chunk.length - overflow, chunk.length))
-            })
-            .then(() => callback(null))
-            .catch(callback)
-        }
+  async _write(chunk: Buffer, _: BufferEncoding, callback: Callback) {
+    // In order to start writing a chunk, we must first create
+    // a file system reference for it
+    if (this.fileHandle === null) {
+      await this._newChunk().catch(callback)
+    }
 
-        // The chunk fits in the max chunk size
-        return this._writeChunk(chunk)
-          .then(() => callback(null))
-          .catch(callback)
-      })
-      .catch(callback)
-  }
+    try {
+      const overflow = this.currentChunkSize + chunk.length - this.chunkSize
+      // The current chunk will be more than our defined part size if we would
+      // write all of it to disk.
+      if (overflow > 0) {
+        // Only write to disk the up to our defined part size.
+        await this._writeChunk(chunk.slice(0, chunk.length - overflow))
+        await this._finishChunk()
+        // We still have some overflow left, so we write it to a new chunk.
+        await this._newChunk()
+        await this._writeChunk(chunk.slice(chunk.length - overflow, chunk.length))
+        callback(null)
+        return
+      }
 
-  _final(callback: () => void) {
-    if (this.fileDescriptor === null) {
-      callback()
-    } else {
-      this._finishChunk()
-        .then(() => callback())
-        .catch(callback)
+      // The chunk is smaller than our defined part size so we can just write it to disk.
+      await this._writeChunk(chunk)
+      callback(null)
+    } catch (error) {
+      callback(error)
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _writeChunk(chunk: any): Promise<void> {
-    return new Promise((resolve, reject) => {
-      fs.write(this.fileDescriptor as number, chunk, (err) => {
-        if (err) {
-          return reject(err)
-        }
-
-        this.currentChunkSize += chunk.length
-        return resolve()
-      })
-    })
-  }
-
-  _finishChunk(): Promise<void> {
-    if (this.fileDescriptor === null) {
-      return Promise.resolve()
+  async _final(callback: Callback) {
+    if (this.fileHandle === null) {
+      callback(null)
+      return
     }
 
-    return new Promise((resolve, reject) => {
-      fs.close(this.fileDescriptor as number, (err) => {
-        if (err) {
-          return reject(err)
-        }
-
-        this.emit('chunkFinished', {
-          path: this.currentChunkPath,
-          size: this.currentChunkSize,
-        })
-        this.currentChunkPath = null
-        this.fileDescriptor = null
-        this.currentChunkSize = null
-        this.part += 1
-        return resolve()
-      })
-    })
+    try {
+      await this._finishChunk()
+      callback(null)
+    } catch (error) {
+      callback(error)
+    }
   }
 
-  _newChunk(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.currentChunkPath = path.join(
-        this.directory,
-        `${this.filenameTemplate}-${this.part}`
-      )
-      fs.open(this.currentChunkPath, 'w', (err, fd) => {
-        if (err) {
-          return reject(err)
-        }
+  async _writeChunk(chunk: Buffer): Promise<void> {
+    await fs.appendFile(this.fileHandle as fs.FileHandle, chunk)
+    this.currentChunkSize += chunk.length
+  }
 
-        this.emit('chunkStarted', this.currentChunkPath)
-        this.currentChunkSize = 0
-        this.fileDescriptor = fd
-        return resolve()
-      })
+  async _finishChunk(): Promise<void> {
+    if (this.fileHandle === null) {
+      return
+    }
+
+    await this.fileHandle.close()
+
+    this.emit('chunkFinished', {
+      path: this.currentChunkPath,
+      size: this.currentChunkSize,
     })
+    this.currentChunkPath = null
+    this.fileHandle = null
+    this.currentChunkSize = 0
+    this.part += 1
+  }
+
+  async _newChunk(): Promise<void> {
+    this.currentChunkPath = path.join(
+      this.directory,
+      `${this.filenameTemplate}-${this.part}`
+    )
+    const fileHandle = await fs.open(this.currentChunkPath, 'w')
+    this.emit('chunkStarted', this.currentChunkPath)
+    this.currentChunkSize = 0
+    this.fileHandle = fileHandle
   }
 }

--- a/lib/models/StreamSplitter.ts
+++ b/lib/models/StreamSplitter.ts
@@ -37,13 +37,13 @@ export default class FileStreamSplitter extends stream.Writable {
   }
 
   async _write(chunk: Buffer, _: BufferEncoding, callback: Callback) {
-    // In order to start writing a chunk, we must first create
-    // a file system reference for it
-    if (this.fileHandle === null) {
-      await this._newChunk().catch(callback)
-    }
-
     try {
+      // In order to start writing a chunk, we must first create
+      // a file system reference for it
+      if (this.fileHandle === null) {
+        await this._newChunk()
+      }
+
       const overflow = this.currentChunkSize + chunk.length - this.chunkSize
       // The current chunk will be more than our defined part size if we would
       // write all of it to disk.

--- a/lib/stores/S3Store.ts
+++ b/lib/stores/S3Store.ts
@@ -1,4 +1,3 @@
-import {strict as assert} from 'node:assert'
 import os from 'node:os'
 import fs, {promises as fsProm} from 'node:fs'
 import stream from 'node:stream/promises'
@@ -65,13 +64,6 @@ export default class S3Store extends DataStore {
   constructor(options: Options) {
     super()
     const {bucket, partSize, ...rest} = options
-    if (options.accessKeyId || options.secretAccessKey) {
-      assert.ok(options.accessKeyId, '[S3Store] `accessKeyId` must be set')
-      assert.ok(options.secretAccessKey, '[S3Store] `secretAccessKey` must be set')
-    } else {
-      assert.ok(options.credentials, '[S3Store] `credentials` must be set')
-    }
-
     this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length']
     this.bucket = bucket
     this.preferredPartSize = partSize || 8 * 1024 * 1024

--- a/lib/stores/S3Store.ts
+++ b/lib/stores/S3Store.ts
@@ -60,10 +60,7 @@ export default class S3Store extends DataStore {
   cache: Map<string, MetadataValue> = new Map()
   client: aws.S3
   preferredPartSize: number
-  maxMultipartParts = 10_000
-  minPartSize = 5 * 1024 * 1024
-  maxPartSize = 5 * 1024 * 1024 * 1024
-  maxObjectSize = 5 * 1024 * 1024 * 1024 * 1024
+  maxMultipartParts = 10_000 as const
 
   constructor(options: Options) {
     super()

--- a/test/Test-StreamSplitter.ts
+++ b/test/Test-StreamSplitter.ts
@@ -1,0 +1,28 @@
+import os from 'node:os'
+import fs from 'node:fs'
+import stream from 'node:stream/promises'
+import {strict as assert} from 'node:assert'
+
+import StreamSplitter from '../lib/models/StreamSplitter'
+
+const fileSize = 20_971_520
+
+describe('StreamSplitter', () => {
+  it('should buffer chunks until optimal part size', async () => {
+    const readStream = fs.createReadStream('test/fixtures/test.pdf')
+    const optimalChunkSize = 8 * 1024 * 1024
+    const parts = [optimalChunkSize, optimalChunkSize, fileSize - optimalChunkSize * 2]
+    let offset = 0
+    let index = 0
+    const splitterStream = new StreamSplitter({
+      chunkSize: optimalChunkSize,
+      directory: os.tmpdir(),
+    }).on('chunkFinished', ({size}) => {
+      offset += size
+      assert.equal(parts[index], size)
+      index++
+    })
+    await stream.pipeline(readStream, splitterStream)
+    assert.equal(offset, fileSize)
+  })
+})


### PR DESCRIPTION
**Before**: uploading a 100 GB file with the default part size of 8 MB would fail the upload as it would be 12.5K parts, while the maximum allowed by S3 is 10K.

**After**: calculating the optimal part size which never exceeds the 10K limit.

Other changes:
 - Modernize `StreamSplitter`
 - Tiny refactors