### PR TITLE
Use http mocks in tests

### DIFF
--- a/test/Test-BaseHandler.ts
+++ b/test/Test-BaseHandler.ts
@@ -1,5 +1,3 @@
-import http from 'node:http'
-import net from 'node:net'
 import {strict as assert} from 'node:assert'
 
 import httpMocks from 'node-mocks-http'
@@ -14,9 +12,7 @@ describe('BaseHandler', () => {
   let res: httpMocks.MockResponse<any>
 
   beforeEach(() => {
-    const req = new http.IncomingMessage(new net.Socket())
-    req.method = 'GET'
-    res = httpMocks.createResponse({req})
+    res = httpMocks.createResponse()
   })
 
   it('constructor must require a DataStore', (done) => {

--- a/test/Test-DeleteHandler.ts
+++ b/test/Test-DeleteHandler.ts
@@ -1,10 +1,10 @@
 import 'should'
 
 import {strict as assert} from 'node:assert'
-import http from 'node:http'
-import net from 'node:net'
+import type http from 'node:http'
 
 import sinon from 'sinon'
+import httpMocks from 'node-mocks-http'
 
 import DataStore from '../lib/stores/DataStore'
 import DeleteHandler from '../lib/handlers/DeleteHandler'
@@ -15,15 +15,13 @@ describe('DeleteHandler', () => {
   const fake_store = sinon.createStubInstance(DataStore)
   let handler: InstanceType<typeof DeleteHandler>
   let req: http.IncomingMessage
-  let res: http.ServerResponse
+  let res: httpMocks.MockResponse<http.ServerResponse>
 
   beforeEach(() => {
     fake_store.remove.resetHistory()
     handler = new DeleteHandler(fake_store, {relativeLocation: true, path})
-    req = new http.IncomingMessage(new net.Socket())
-    req.url = handler.generateUrl(req, '1234')
-    req.method = 'HEAD'
-    res = new http.ServerResponse(req)
+    req = {url: `${path}/1234`, method: 'DELETE'} as http.IncomingMessage
+    res = httpMocks.createResponse()
   })
 
   it('should 404 if no file id match', () => {

--- a/test/Test-GetHandler.ts
+++ b/test/Test-GetHandler.ts
@@ -4,9 +4,9 @@ import {strict as assert} from 'node:assert'
 import fs from 'node:fs'
 import stream from 'node:stream'
 import http from 'node:http'
-import net from 'node:net'
 
 import sinon from 'sinon'
+import httpMocks from 'node-mocks-http'
 
 import GetHandler from '../lib/handlers/GetHandler'
 import DataStore from '../lib/stores/DataStore'
@@ -20,9 +20,8 @@ describe('GetHandler', () => {
   let res: http.ServerResponse
 
   beforeEach(() => {
-    req = new http.IncomingMessage(new net.Socket())
-    req.method = 'GET'
-    res = new http.ServerResponse(req)
+    req = httpMocks.createRequest({method: 'GET'})
+    res = httpMocks.createResponse({req})
   })
 
   describe('test error responses', () => {

--- a/test/Test-HeadHandler.ts
+++ b/test/Test-HeadHandler.ts
@@ -1,8 +1,8 @@
 import {strict as assert} from 'node:assert'
 import http from 'node:http'
-import net from 'node:net'
 
 import sinon from 'sinon'
+import httpMocks from 'node-mocks-http'
 
 import DataStore from '../lib/stores/DataStore'
 import HeadHandler from '../lib/handlers/HeadHandler'
@@ -14,13 +14,11 @@ describe('HeadHandler', () => {
   const fake_store = sinon.createStubInstance(DataStore)
   const handler = new HeadHandler(fake_store, {relativeLocation: true, path})
   let req: http.IncomingMessage
-  let res: http.ServerResponse
+  let res: httpMocks.MockResponse<http.ServerResponse>
 
   beforeEach(() => {
-    req = new http.IncomingMessage(new net.Socket())
-    req.url = handler.generateUrl(req, '1234')
-    req.method = 'HEAD'
-    res = new http.ServerResponse(req)
+    req = {url: `${path}/1234`, method: 'HEAD'} as http.IncomingMessage
+    res = httpMocks.createResponse({req})
   })
 
   it('should 404 if no file id match', () => {

--- a/test/Test-OptionsHandler.ts
+++ b/test/Test-OptionsHandler.ts
@@ -2,7 +2,8 @@ import 'should'
 
 import {strict as assert} from 'node:assert'
 import http from 'node:http'
-import net from 'node:net'
+
+import httpMocks from 'node-mocks-http'
 
 import OptionsHandler from '../lib/handlers/OptionsHandler'
 import DataStore from '../lib/stores/DataStore'
@@ -14,13 +15,11 @@ describe('OptionsHandler', () => {
   const handler = new OptionsHandler(store, options)
 
   let req: http.IncomingMessage
-  let res: http.ServerResponse
+  let res: httpMocks.MockResponse<http.ServerResponse>
 
   beforeEach(() => {
-    req = new http.IncomingMessage(new net.Socket())
-    req.url = handler.generateUrl(req, '1234')
-    req.method = 'OPTIONS'
-    res = new http.ServerResponse(req)
+    req = {url: `${options.path}/1234`, method: 'OPTIONS'} as http.IncomingMessage
+    res = httpMocks.createResponse({req})
   })
 
   it('send() should set headers and 204', async () => {

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -3,8 +3,8 @@ import 'should'
 
 import {strict as assert} from 'node:assert'
 import http from 'node:http'
-import net from 'node:net'
 
+import httpMocks from 'node-mocks-http'
 import sinon from 'sinon'
 
 import DataStore from '../lib/stores/DataStore'
@@ -19,16 +19,14 @@ const SERVER_OPTIONS = {
 
 describe('PostHandler', () => {
   let req: http.IncomingMessage
-  let res: http.ServerResponse
+  let res: httpMocks.MockResponse<http.ServerResponse>
 
   const fake_store = sinon.createStubInstance(DataStore)
   fake_store.hasExtension.withArgs('creation-defer-length').returns(true)
 
   beforeEach(() => {
-    req = new http.IncomingMessage(new net.Socket())
-    req.method = 'POST'
-    req.url = '/files'
-    res = new http.ServerResponse(req)
+    req = {url: '/files', method: 'POST'} as http.IncomingMessage
+    res = httpMocks.createResponse({req})
   })
 
   describe('constructor()', () => {
@@ -104,11 +102,7 @@ describe('PostHandler', () => {
         })
         req.headers = {'upload-length': '1000', host: 'localhost:3000'}
         await handler.send(req, res)
-        assert.equal(
-          // @ts-expect-error works but not in types
-          res._header.includes('Location: //localhost:3000/test/output/1234'),
-          true
-        )
+        assert.equal(res._getHeaders().location, '//localhost:3000/test/output/1234')
         assert.equal(res.statusCode, 201)
       })
     })


### PR DESCRIPTION
Since Node.js 19.1.0, `http.IncomingRequest` has some immutable properties, such as `headers`. We tried to override it in tests which would fail. This PR refactors it to use `node-http-mocks`, which as already in the project.  