### PR TITLE
Overhaul the events and hook callback system

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
   "plugins": ["@typescript-eslint", "prettier"],
   "rules": {
     "no-new":"off",
+    "complexity":"off",
     "camelcase": "off",
     "no-unused-vars": "off",
     "no-warning-comments":"off",

--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -32,7 +32,12 @@ type Handlers = {
 }
 
 interface TusEvents {
-  [EVENTS.POST_CREATE]: (req: http.IncomingMessage, upload: Upload, url: string) => void
+  [EVENTS.POST_CREATE]: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    upload: Upload,
+    url: string
+  ) => void
   [EVENTS.POST_FINISH]: (
     req: http.IncomingMessage,
     res: http.ServerResponse,

--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -38,7 +38,11 @@ interface TusEvents {
     res: http.ServerResponse,
     upload: Upload
   ) => void
-  [EVENTS.POST_TERMINATE]: (req: http.IncomingMessage, id: string) => void
+  [EVENTS.POST_TERMINATE]: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    id: string
+  ) => void
 }
 
 type on = EventEmitter['on']

--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -11,7 +11,13 @@ import PostHandler from './handlers/PostHandler'
 import DeleteHandler from './handlers/DeleteHandler'
 import RequestValidator from './validators/RequestValidator'
 
-import {ERRORS, EXPOSED_HEADERS, REQUEST_METHODS, TUS_RESUMABLE} from './constants'
+import {
+  EVENTS,
+  ERRORS,
+  EXPOSED_HEADERS,
+  REQUEST_METHODS,
+  TUS_RESUMABLE,
+} from './constants'
 
 import type stream from 'node:stream'
 import type {DataStore, ServerOptions, RouteHandler, Upload} from '../types'
@@ -24,16 +30,28 @@ type Handlers = {
   POST: InstanceType<typeof PostHandler>
   DELETE: InstanceType<typeof DeleteHandler>
 }
+
 interface TusEvents {
-  EVENT_FILE_CREATED: (event: {file: Upload}) => void
-  EVENT_ENDPOINT_CREATED: (event: {url: string}) => void
-  EVENT_UPLOAD_COMPLETE: (event: {file: Upload}) => void
-  EVENT_FILE_DELETED: (event: {file_id: string}) => void
+  [EVENTS.POST_CREATE]: (req: http.IncomingMessage, upload: Upload, url: string) => void
+  [EVENTS.POST_FINISH]: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    upload: Upload
+  ) => void
+  [EVENTS.POST_TERMINATE]: (req: http.IncomingMessage, id: string) => void
 }
+
+type on = EventEmitter['on']
+type emit = EventEmitter['emit']
 export declare interface Server {
-  on<U extends keyof TusEvents>(event: U, listener: TusEvents[U]): this
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  on(eventName: string | symbol, listener: (...args: any[]) => void): this
+  on<Event extends keyof TusEvents>(event: Event, listener: TusEvents[Event]): this
+  on(eventName: Parameters<on>[0], listener: Parameters<on>[1]): this
+
+  emit<Event extends keyof TusEvents>(
+    event: Event,
+    listener: TusEvents[Event]
+  ): ReturnType<emit>
+  emit(eventName: Parameters<emit>[0], listener: Parameters<emit>[1]): ReturnType<emit>
 }
 
 const log = debug('tus-node-server')

--- a/lib/Server.ts
+++ b/lib/Server.ts
@@ -38,6 +38,11 @@ interface TusEvents {
     upload: Upload,
     url: string
   ) => void
+  [EVENTS.POST_RECEIVE]: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    upload: Upload
+  ) => void
   [EVENTS.POST_FINISH]: (
     req: http.IncomingMessage,
     res: http.ServerResponse,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,5 @@
 export const REQUEST_METHODS = ['POST', 'HEAD', 'PATCH', 'OPTIONS', 'DELETE'] as const
+
 export const HEADERS = [
   'Authorization',
   'Content-Type',
@@ -15,9 +16,15 @@ export const HEADERS = [
   'X-HTTP-Method-Override',
   'X-Requested-With',
 ] as const
+
 export const HEADERS_LOWERCASE = HEADERS.map((header) => {
   return header.toLowerCase()
 }) as Array<Lowercase<typeof HEADERS[number]>>
+
+export const ALLOWED_HEADERS = HEADERS.join(', ')
+export const ALLOWED_METHODS = REQUEST_METHODS.join(', ')
+export const EXPOSED_HEADERS = HEADERS.join(', ')
+
 export const ERRORS = {
   MISSING_OFFSET: {
     status_code: 403,
@@ -64,19 +71,12 @@ export const ERRORS = {
     body: 'expiration extension is not (yet) supported.\n',
   },
 } as const
-export const EVENT_ENDPOINT_CREATED = 'EVENT_ENDPOINT_CREATED' as const
-export const EVENT_FILE_CREATED = 'EVENT_FILE_CREATED' as const
-export const EVENT_UPLOAD_COMPLETE = 'EVENT_UPLOAD_COMPLETE' as const
-export const EVENT_FILE_DELETED = 'EVENT_FILE_DELETED' as const
-export const EVENTS = {
-  EVENT_ENDPOINT_CREATED,
-  EVENT_FILE_CREATED,
-  EVENT_UPLOAD_COMPLETE,
-  EVENT_FILE_DELETED,
-} as const
-export const ALLOWED_HEADERS = HEADERS.join(', ')
-export const ALLOWED_METHODS = REQUEST_METHODS.join(', ')
-export const EXPOSED_HEADERS = HEADERS.join(', ')
+
+export const POST_CREATE = 'POST_CREATE' as const
+export const POST_FINISH = 'POST_FINISH' as const
+export const POST_TERMINATE = 'POST_TERMINATE' as const
+export const EVENTS = {POST_CREATE, POST_FINISH, POST_TERMINATE} as const
+
 export const MAX_AGE = 86_400 as const
 export const TUS_RESUMABLE = '1.0.0' as const
 export const TUS_VERSION = ['1.0.0'] as const

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -73,9 +73,10 @@ export const ERRORS = {
 } as const
 
 export const POST_CREATE = 'POST_CREATE' as const
+export const POST_RECEIVE = 'POST_RECEIVE' as const
 export const POST_FINISH = 'POST_FINISH' as const
 export const POST_TERMINATE = 'POST_TERMINATE' as const
-export const EVENTS = {POST_CREATE, POST_FINISH, POST_TERMINATE} as const
+export const EVENTS = {POST_CREATE, POST_RECEIVE, POST_FINISH, POST_TERMINATE} as const
 
 export const MAX_AGE = 86_400 as const
 export const TUS_RESUMABLE = '1.0.0' as const

--- a/lib/handlers/DeleteHandler.ts
+++ b/lib/handlers/DeleteHandler.ts
@@ -11,7 +11,7 @@ export default class DeleteHandler extends BaseHandler {
     }
 
     await this.store.remove(id)
-    this.emit(EVENTS.EVENT_FILE_DELETED, {file_id: id})
+    this.emit(EVENTS.POST_TERMINATE, req, id)
     return this.write(res, 204, {})
   }
 }

--- a/lib/handlers/DeleteHandler.ts
+++ b/lib/handlers/DeleteHandler.ts
@@ -11,7 +11,8 @@ export default class DeleteHandler extends BaseHandler {
     }
 
     await this.store.remove(id)
-    this.emit(EVENTS.POST_TERMINATE, req, id)
-    return this.write(res, 204, {})
+    const writtenRes = this.write(res, 204, {})
+    this.emit(EVENTS.POST_TERMINATE, req, writtenRes, id)
+    return writtenRes
   }
 }

--- a/lib/handlers/PatchHandler.ts
+++ b/lib/handlers/PatchHandler.ts
@@ -79,6 +79,7 @@ export default class PatchHandler extends BaseHandler {
 
     const newOffset = await this.store.write(req, id, offset)
     upload.offset = newOffset
+    this.emit(EVENTS.POST_RECEIVE, req, res, upload)
     if (newOffset === upload.size && this.options.onUploadFinish) {
       try {
         res = await this.options.onUploadFinish(req, res, upload)

--- a/lib/handlers/PatchHandler.ts
+++ b/lib/handlers/PatchHandler.ts
@@ -78,12 +78,12 @@ export default class PatchHandler extends BaseHandler {
     }
 
     const newOffset = await this.store.write(req, id, offset)
-    if (newOffset === upload.size) {
+    upload.offset = newOffset
+    if (newOffset === upload.size && this.options.onUploadFinish) {
       try {
-        upload.offset = newOffset
-        await this.options.onUploadFinish?.(req, upload)
+        res = await this.options.onUploadFinish(req, res, upload)
       } catch (error) {
-        log(`onUploadFinish error: ${error}`)
+        log(`onUploadFinish: ${error.body}`)
         throw error
       }
     }

--- a/lib/handlers/PostHandler.ts
+++ b/lib/handlers/PostHandler.ts
@@ -70,7 +70,7 @@ export default class PostHandler extends BaseHandler {
     try {
       await this.options.onUploadCreate?.(req, upload)
     } catch (error) {
-      log(`onUploadCreate error: ${error}`)
+      log(`onUploadCreate error: ${JSON.stringify(error)}`)
       throw error
     }
 

--- a/lib/handlers/PostHandler.ts
+++ b/lib/handlers/PostHandler.ts
@@ -60,31 +60,46 @@ export default class PostHandler extends BaseHandler {
       throw ERRORS.FILE_WRITE_ERROR
     }
 
-    const file = new Upload({
+    const upload = new Upload({
       id,
       size: upload_length ? Number.parseInt(upload_length, 10) : undefined,
       offset: 0,
       metadata: upload_metadata,
     })
 
-    const obj = await this.store.create(file)
-    this.emit(EVENTS.EVENT_FILE_CREATED, {file: obj})
+    try {
+      await this.options.onUploadCreate?.(req, upload)
+    } catch (error) {
+      log(`onUploadCreate error: ${error}`)
+      throw error
+    }
 
-    const url = this.generateUrl(req, file.id)
-    this.emit(EVENTS.EVENT_ENDPOINT_CREATED, {url})
+    await this.store.create(upload)
+    const url = this.generateUrl(req, upload.id)
 
-    const optional_headers: {
+    this.emit(EVENTS.POST_CREATE, req, upload, url)
+
+    let newOffset
+    let isFinal = false
+    const headers: {
       'Upload-Offset'?: string
       'Upload-Expires'?: string
     } = {}
 
     // The request MIGHT include a Content-Type header when using creation-with-upload extension
     if (!RequestValidator.isInvalidHeader('content-type', req.headers['content-type'])) {
-      const new_offset = await this.store.write(req, file.id, 0)
-      optional_headers['Upload-Offset'] = new_offset.toString()
+      newOffset = await this.store.write(req, upload.id, 0)
+      headers['Upload-Offset'] = newOffset.toString()
+      isFinal = newOffset === Number.parseInt(upload_length as string, 10)
+      upload.offset = newOffset
 
-      if (new_offset === Number.parseInt(upload_length as string, 10)) {
-        this.emit(EVENTS.EVENT_UPLOAD_COMPLETE, {file})
+      if (isFinal) {
+        try {
+          await this.options.onUploadFinish?.(req, upload)
+        } catch (error) {
+          log(`onUploadFinish error: ${error}`)
+          throw error
+        }
       }
     }
 
@@ -93,18 +108,24 @@ export default class PostHandler extends BaseHandler {
     if (
       this.store.hasExtension('expiration') &&
       this.store.getExpiration() > 0 &&
-      file.creation_date
+      upload.creation_date
     ) {
-      const created = await this.store.getUpload(file.id)
+      const created = await this.store.getUpload(upload.id)
       if (created.offset !== Number.parseInt(upload_length as string, 10)) {
-        const creation = new Date(file.creation_date)
+        const creation = new Date(upload.creation_date)
         // Value MUST be in RFC 7231 datetime format
-        optional_headers['Upload-Expires'] = new Date(
+        headers['Upload-Expires'] = new Date(
           creation.getTime() + this.store.getExpiration()
         ).toUTCString()
       }
     }
 
-    return this.write(res, 201, {Location: url, ...optional_headers})
+    const writtenRes = this.write(res, 201, {Location: url, ...headers})
+
+    if (isFinal) {
+      this.emit(EVENTS.POST_FINISH, req, writtenRes, upload)
+    }
+
+    return writtenRes
   }
 }

--- a/lib/stores/S3Store.ts
+++ b/lib/stores/S3Store.ts
@@ -18,7 +18,14 @@ function calcOffsetFromParts(parts?: aws.S3.Parts) {
   return parts && parts.length > 0 ? parts.reduce((a, b) => a + b.Size, 0) : 0
 }
 
-type Options = {bucket: string; partSize?: number} & aws.S3.Types.ClientConfiguration
+type Options = {
+  // Name of the bucket.
+  bucket: string
+  // The preferred part size for parts send to S3. Can not be lower than 5MB or more than 500MB.
+  // The server calculates the optimal part size, which takes this size into account,
+  // but may increase it to not exceed the S3 10K parts limit.
+  partSize?: number
+} & aws.S3.Types.ClientConfiguration
 
 type MetadataValue = {file: Upload; upload_id: string}
 // Implementation (based on https://github.com/tus/tusd/blob/master/s3store/s3store.go)

--- a/test/Test-DeleteHandler.ts
+++ b/test/Test-DeleteHandler.ts
@@ -41,10 +41,11 @@ describe('DeleteHandler', () => {
     assert.equal(res.statusCode, 204)
   })
 
-  it(`must fire the ${EVENTS.EVENT_FILE_DELETED} event`, (done) => {
+  it(`must fire the ${EVENTS.POST_TERMINATE} event`, (done) => {
     fake_store.remove.resolves()
-    handler.on(EVENTS.EVENT_FILE_DELETED, (event) => {
-      assert.equal(event.file_id, '1234')
+    handler.on(EVENTS.POST_TERMINATE, (request, id) => {
+      assert.deepStrictEqual(req, request)
+      assert.equal(id, '1234')
       done()
     })
     handler.send(req, res)

--- a/test/Test-PatchHandler.ts
+++ b/test/Test-PatchHandler.ts
@@ -35,7 +35,7 @@ describe('PatchHandler', () => {
   })
 
   it('should call onUploadFinished hook', async function () {
-    const spy = sinon.spy()
+    const spy = sinon.stub().resolvesArg(1)
     const handler = new PatchHandler(store, {
       path: '/test/output',
       onUploadFinish: spy,
@@ -50,7 +50,7 @@ describe('PatchHandler', () => {
 
     await handler.send(req, res)
     assert.equal(spy.calledOnce, true)
-    const upload = spy.args[0][1]
+    const upload = spy.args[0][2]
     assert.equal(upload.offset, 1024)
     assert.equal(upload.size, 1024)
   })

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -197,7 +197,7 @@ describe('PostHandler', () => {
           path: '/test/output',
           namingFunction: () => '1234',
         })
-        handler.on(EVENTS.POST_CREATE, (_, __, url) => {
+        handler.on(EVENTS.POST_CREATE, (_, __, ___, url) => {
           assert.strictEqual(url, 'http://localhost:3000/test/output/1234')
           done()
         })
@@ -217,7 +217,7 @@ describe('PostHandler', () => {
           relativeLocation: true,
           namingFunction: () => '1234',
         })
-        handler.on(EVENTS.POST_CREATE, (_, __, url) => {
+        handler.on(EVENTS.POST_CREATE, (_, __, ___, url) => {
           assert.strictEqual(url, '/test/output/1234')
           done()
         })
@@ -249,7 +249,7 @@ describe('PostHandler', () => {
 
       it('should call onUploadCreate hook', async function () {
         const store = sinon.createStubInstance(DataStore)
-        const spy = sinon.spy()
+        const spy = sinon.stub().resolvesArg(1)
         const handler = new PostHandler(store, {
           path: '/test/output',
           onUploadCreate: spy,
@@ -263,14 +263,14 @@ describe('PostHandler', () => {
 
         await handler.send(req, res)
         assert.equal(spy.calledOnce, true)
-        const upload = spy.args[0][1]
+        const upload = spy.args[0][2]
         assert.equal(upload.offset, 0)
         assert.equal(upload.size, 1024)
       })
 
       it('should call onUploadFinish hook when creation-with-upload is used', async function () {
         const store = sinon.createStubInstance(DataStore)
-        const spy = sinon.spy()
+        const spy = sinon.stub().resolvesArg(1)
         const handler = new PostHandler(store, {
           path: '/test/output',
           onUploadFinish: spy,
@@ -286,7 +286,7 @@ describe('PostHandler', () => {
 
         await handler.send(req, res)
         assert.equal(spy.calledOnce, true)
-        const upload = spy.args[0][1]
+        const upload = spy.args[0][2]
         assert.equal(upload.offset, 1024)
         assert.equal(upload.size, 1024)
       })

--- a/test/Test-PostHandler.ts
+++ b/test/Test-PostHandler.ts
@@ -10,7 +10,7 @@ import sinon from 'sinon'
 import DataStore from '../lib/stores/DataStore'
 import PostHandler from '../lib/handlers/PostHandler'
 import {EVENTS} from '../lib/constants'
-import File from '../lib/models/Upload'
+import Upload from '../lib/models/Upload'
 
 const SERVER_OPTIONS = {
   path: '/test',
@@ -173,34 +173,32 @@ describe('PostHandler', () => {
     })
 
     describe('events', () => {
-      it(`must fire the ${EVENTS.EVENT_FILE_CREATED} event`, (done) => {
-        const fake_store = sinon.createStubInstance(DataStore)
+      it(`must fire the ${EVENTS.POST_CREATE} event`, async () => {
+        const store = sinon.createStubInstance(DataStore)
+        const file = new Upload({id: '1234', size: 1024, offset: 0})
+        const handler = new PostHandler(store, SERVER_OPTIONS)
+        const spy = sinon.spy()
 
-        const file = new File({id: '1234', size: 10, offset: 0})
-        fake_store.create.resolves(file)
+        req.headers = {'upload-length': '1024'}
+        store.create.resolves(file)
+        handler.on(EVENTS.POST_CREATE, spy)
 
-        const handler = new PostHandler(fake_store, SERVER_OPTIONS)
-        handler.on(EVENTS.EVENT_FILE_CREATED, (obj) => {
-          assert.strictEqual(obj.file, file)
-          done()
-        })
-
-        req.headers = {'upload-length': '1000'}
-        handler.send(req, res)
+        await handler.send(req, res)
+        assert.equal(spy.calledOnce, true)
       })
 
-      it(`must fire the ${EVENTS.EVENT_ENDPOINT_CREATED} event with absolute URL`, (done) => {
+      it(`must fire the ${EVENTS.POST_CREATE} event with absolute URL`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)
 
-        const file = new File({id: '1234', size: 10, offset: 0})
+        const file = new Upload({id: '1234', size: 10, offset: 0})
         fake_store.create.resolves(file)
 
         const handler = new PostHandler(fake_store, {
           path: '/test/output',
           namingFunction: () => '1234',
         })
-        handler.on(EVENTS.EVENT_ENDPOINT_CREATED, (obj) => {
-          assert.strictEqual(obj.url, 'http://localhost:3000/test/output/1234')
+        handler.on(EVENTS.POST_CREATE, (_, __, url) => {
+          assert.strictEqual(url, 'http://localhost:3000/test/output/1234')
           done()
         })
 
@@ -208,10 +206,10 @@ describe('PostHandler', () => {
         handler.send(req, res)
       })
 
-      it(`must fire the ${EVENTS.EVENT_ENDPOINT_CREATED} event with relative URL`, (done) => {
+      it(`must fire the ${EVENTS.POST_CREATE} event with relative URL`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)
 
-        const file = new File({id: '1234', size: 10, offset: 0})
+        const file = new Upload({id: '1234', size: 10, offset: 0})
         fake_store.create.resolves(file)
 
         const handler = new PostHandler(fake_store, {
@@ -219,8 +217,8 @@ describe('PostHandler', () => {
           relativeLocation: true,
           namingFunction: () => '1234',
         })
-        handler.on(EVENTS.EVENT_ENDPOINT_CREATED, (obj) => {
-          assert.strictEqual(obj.url, '/test/output/1234')
+        handler.on(EVENTS.POST_CREATE, (_, __, url) => {
+          assert.strictEqual(url, '/test/output/1234')
           done()
         })
 
@@ -228,7 +226,7 @@ describe('PostHandler', () => {
         handler.send(req, res)
       })
 
-      it(`must fire the ${EVENTS.EVENT_UPLOAD_COMPLETE} event when upload is complete with single request`, (done) => {
+      it(`must fire the ${EVENTS.POST_CREATE} event when upload is complete with single request`, (done) => {
         const fake_store = sinon.createStubInstance(DataStore)
 
         const upload_length = 1000
@@ -237,7 +235,7 @@ describe('PostHandler', () => {
         fake_store.write.resolves(upload_length)
 
         const handler = new PostHandler(fake_store, {path: '/test/output'})
-        handler.on(EVENTS.EVENT_UPLOAD_COMPLETE, () => {
+        handler.on(EVENTS.POST_CREATE, () => {
           done()
         })
 
@@ -249,29 +247,48 @@ describe('PostHandler', () => {
         handler.send(req, res)
       })
 
-      it(`must not fire the ${EVENTS.EVENT_UPLOAD_COMPLETE} event when upload-length is defered`, (done) => {
-        const fake_store = sinon.createStubInstance(DataStore)
-
-        const upload_length = 1000
-
-        fake_store.create.resolvesArg(0)
-        fake_store.write.resolves(upload_length)
-        fake_store.hasExtension.withArgs('creation-defer-length').returns(true)
-
-        const handler = new PostHandler(fake_store, {path: '/test/output'})
-        handler.on(EVENTS.EVENT_UPLOAD_COMPLETE, () => {
-          done(new Error('test'))
+      it('should call onUploadCreate hook', async function () {
+        const store = sinon.createStubInstance(DataStore)
+        const spy = sinon.spy()
+        const handler = new PostHandler(store, {
+          path: '/test/output',
+          onUploadCreate: spy,
         })
 
         req.headers = {
-          'upload-defer-length': '1',
+          'upload-length': '1024',
+          host: 'localhost:3000',
+        }
+        store.create.resolvesArg(0)
+
+        await handler.send(req, res)
+        assert.equal(spy.calledOnce, true)
+        const upload = spy.args[0][1]
+        assert.equal(upload.offset, 0)
+        assert.equal(upload.size, 1024)
+      })
+
+      it('should call onUploadFinish hook when creation-with-upload is used', async function () {
+        const store = sinon.createStubInstance(DataStore)
+        const spy = sinon.spy()
+        const handler = new PostHandler(store, {
+          path: '/test/output',
+          onUploadFinish: spy,
+        })
+
+        req.headers = {
+          'upload-length': '1024',
           host: 'localhost:3000',
           'content-type': 'application/offset+octet-stream',
         }
-        handler
-          .send(req, res)
-          .then(() => done())
-          .catch(done)
+        store.create.resolvesArg(0)
+        store.write.resolves(1024)
+
+        await handler.send(req, res)
+        assert.equal(spy.calledOnce, true)
+        const upload = spy.args[0][1]
+        assert.equal(upload.offset, 1024)
+        assert.equal(upload.size, 1024)
       })
     })
   })

--- a/test/Test-Server.ts
+++ b/test/Test-Server.ts
@@ -255,7 +255,7 @@ describe('Server', () => {
     })
 
     it('should fire when an endpoint is created', (done) => {
-      server.on(EVENTS.POST_CREATE, (_, upload, url) => {
+      server.on(EVENTS.POST_CREATE, (_, __, upload, url) => {
         assert.ok(url)
         assert.equal(upload.size, 12_345_678)
         done()
@@ -324,7 +324,7 @@ describe('Server', () => {
       const server = new Server({
         path: '/test/output',
         datastore: new FileStore({directory: './test/output'}),
-        onUploadCreate() {
+        async onUploadCreate() {
           throw {body: 'no', status_code: 500}
         },
       })
@@ -358,11 +358,11 @@ describe('Server', () => {
         })
     })
 
-    it('should call onUploadCreate and return its error to the client with creation-with-upload ', (done) => {
+    it('should call onUploadFinish and return its error to the client with creation-with-upload ', (done) => {
       const server = new Server({
         path: '/test/output',
         datastore: new FileStore({directory: './test/output'}),
-        onUploadFinish() {
+        async onUploadFinish() {
           throw {body: 'no', status_code: 500}
         },
       })
@@ -391,11 +391,11 @@ describe('Server', () => {
         .then((res) => {
           request(server.listen())
             .patch(removeProtocol(res.headers.location))
-            .send('test')
             .set('Tus-Resumable', TUS_RESUMABLE)
             .set('Upload-Offset', '0')
             .set('Upload-Length', length)
             .set('Content-Type', 'application/offset+octet-stream')
+            .send('test')
             .end((err) => {
               if (err) {
                 done(err)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,6 @@
 import type http from 'node:http'
+import type {EventEmitter} from 'node:events'
+
 import UploadModel from '../lib/models/Upload'
 
 import BaseStore from '../lib/stores/DataStore'
@@ -6,11 +8,52 @@ import FileStore from '../lib/stores/FileStore'
 import GCSDataStore from '../lib/stores/GCSDataStore'
 import S3Store from '../lib/stores/S3Store'
 
+import {EVENTS} from '../lib/constants'
+
 export type ServerOptions = {
+  // The route to accept requests.
   path: string
+  // Return a relative URL as the `Location` header.
   relativeLocation?: boolean
+  // Allow `Forwarded`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers
+  // to override the `Location` header returned by the server.
   respectForwardedHeaders?: boolean
+  // Control how you want to name files.
+  // It is important to make these unique to prevent data loss. Only use it if you really need to.
+  // Default uses `crypto.randomBytes(16).toString('hex')`.
   namingFunction?: (req: http.IncomingMessage) => string
+  // `onUploadCreate` will be invoked before a new upload is created, if the
+  // property is supplied. If the callback returns true, the upload will be created.
+  // Otherwise the HTTP request will be aborted. This can be used to implement validation of upload metadata etc.
+  onUploadCreate?: (req: http.IncomingMessage, upload: Upload) => Promise<void>
+  // `onUploadFinish` will be invoked after an upload is completed but before
+  // a response is returned to the client. Error responses from the callback will be passed
+  // back to the client. This can be used to implement post-processing validation.
+  onUploadFinish?: (req: http.IncomingMessage, upload: Upload) => Promise<void>
+}
+
+export interface TusEvents {
+  [EVENTS.POST_CREATE]: (req: http.IncomingMessage, upload: Upload, id: string) => void
+  [EVENTS.POST_FINISH]: (req: http.IncomingMessage, upload: Upload) => void
+  [EVENTS.POST_TERMINATE]: (req: http.IncomingMessage, id: string) => void
+}
+
+export interface Events {
+  on<Event extends keyof TusEvents>(event: Event, listener: TusEvents[Event]): this
+  // We could get the type of the method `on` but setting that won't work with overloading.
+  on(
+    eventName: Parameters<EventEmitter['on']>[0],
+    listener: Parameters<EventEmitter['on']>[1]
+  ): ReturnType<EventEmitter['on']>
+
+  emit<Event extends keyof TusEvents>(
+    event: Event,
+    listener: TusEvents[Event]
+  ): ReturnType<EventEmitter['emit']>
+  emit(
+    eventName: Parameters<EventEmitter['emit']>[0],
+    listener: Parameters<EventEmitter['emit']>[1]
+  ): ReturnType<EventEmitter['emit']>
 }
 
 export type Upload = InstanceType<typeof UploadModel>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,4 @@
 import type http from 'node:http'
-import type {EventEmitter} from 'node:events'
 
 import UploadModel from '../lib/models/Upload'
 
@@ -7,8 +6,6 @@ import BaseStore from '../lib/stores/DataStore'
 import FileStore from '../lib/stores/FileStore'
 import GCSDataStore from '../lib/stores/GCSDataStore'
 import S3Store from '../lib/stores/S3Store'
-
-import {EVENTS} from '../lib/constants'
 
 export type ServerOptions = {
   // The route to accept requests.
@@ -30,30 +27,6 @@ export type ServerOptions = {
   // a response is returned to the client. Error responses from the callback will be passed
   // back to the client. This can be used to implement post-processing validation.
   onUploadFinish?: (req: http.IncomingMessage, upload: Upload) => Promise<void>
-}
-
-export interface TusEvents {
-  [EVENTS.POST_CREATE]: (req: http.IncomingMessage, upload: Upload, id: string) => void
-  [EVENTS.POST_FINISH]: (req: http.IncomingMessage, upload: Upload) => void
-  [EVENTS.POST_TERMINATE]: (req: http.IncomingMessage, id: string) => void
-}
-
-export interface Events {
-  on<Event extends keyof TusEvents>(event: Event, listener: TusEvents[Event]): this
-  // We could get the type of the method `on` but setting that won't work with overloading.
-  on(
-    eventName: Parameters<EventEmitter['on']>[0],
-    listener: Parameters<EventEmitter['on']>[1]
-  ): ReturnType<EventEmitter['on']>
-
-  emit<Event extends keyof TusEvents>(
-    event: Event,
-    listener: TusEvents[Event]
-  ): ReturnType<EventEmitter['emit']>
-  emit(
-    eventName: Parameters<EventEmitter['emit']>[0],
-    listener: Parameters<EventEmitter['emit']>[1]
-  ): ReturnType<EventEmitter['emit']>
 }
 
 export type Upload = InstanceType<typeof UploadModel>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,11 +22,19 @@ export type ServerOptions = {
   // `onUploadCreate` will be invoked before a new upload is created, if the
   // property is supplied. If the callback returns true, the upload will be created.
   // Otherwise the HTTP request will be aborted. This can be used to implement validation of upload metadata etc.
-  onUploadCreate?: (req: http.IncomingMessage, upload: Upload) => Promise<void>
+  onUploadCreate?: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    upload: Upload
+  ) => Promise<http.ServerResponse>
   // `onUploadFinish` will be invoked after an upload is completed but before
   // a response is returned to the client. Error responses from the callback will be passed
   // back to the client. This can be used to implement post-processing validation.
-  onUploadFinish?: (req: http.IncomingMessage, upload: Upload) => Promise<void>
+  onUploadFinish?: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    upload: Upload
+  ) => Promise<http.ServerResponse>
 }
 
 export type Upload = InstanceType<typeof UploadModel>


### PR DESCRIPTION
Closes #336 
Refs: #309 

- Remove `EVENT_ENDPOINT_CREATED`, `EVENT_FILE_CREATED`, `EVENT_UPLOAD_COMPLETE`, `EVENT_FILE_DELETED`
- Create `POST_CREATE`, `POST_RECEIVE`, `POST_FINISH`, `POST_TERMINATE`.
- Create blocking callbacks `onUploadCreate` and `onUploadFinish`. Error returned will be send back to the client.

Currently the error thrown in the callbacks expects an object `{body: 'some message', status_code: 500}`, which is consistent with the rest of our errors and has a fallback here:

https://github.com/tus/tus-node-server/blob/accb18b2f53d113ded2e176213f353ccc4de8f48/lib/Server.ts#L176-L184

This will be properly documented. But as I'm completely rewriting the readme and splitting up the packages, I'll do that when I get to it.