### PR TITLE
@tus/s3-store: add `s3ClientConfig` option

### DIFF
--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -67,7 +67,7 @@ but may increase it to not exceed the S3 10K parts limit.
 
 Options to pass to the AWS S3 SDK.
 Checkout the [`S3ClientConfig`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html)
-docs for the supported options. Configuring your preferred method of authentication and region is required.
+docs for the supported options. You need to at least set the `region`, `bucket` name, and your preferred method of authentication. 
 
 ## Extensions
 

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -67,6 +67,12 @@ The preferred part size for parts send to S3. Can not be lower than 5MB or more 
 The server calculates the optimal part size, which takes this size into account,
 but may increase it to not exceed the S3 10K parts limit.
 
+#### `options.s3ClientConfig`
+
+Options to pass to the AWS S3 SDK.
+Checkout the [`S3ClientConfig`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html)
+docs for the supported options. Configuring your preferred method of authentication and region is required.
+
 ## Extensions
 
 The tus protocol supports optional [extensions][]. Below is a table of the supported extensions in `@tus/s3-store`.
@@ -96,12 +102,13 @@ const server = new Server({
   datastore: new S3Store({
     bucket: 'bucket-name',
     partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MB,
-    credentials: new aws.ECSCredentials({
-      httpOptions: {timeout: 5000},
-      maxRetries: 10,
-    }),
-    region: 'eu-west-1',
-    tmpDirPrefix: 'tus-s3-store',
+    s3ClientConfig: {
+      region: 'eu-west-1',
+      credentials: new aws.ECSCredentials({
+        httpOptions: {timeout: 5000},
+        maxRetries: 10,
+      }),
+    },
   }),
 })
 // ...

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -53,10 +53,6 @@ This package exports `S3Store`. There is no default export.
 
 Creates a new AWS S3 store with options.
 
-> **Note**
-> All options except for `bucket` and `partSize` are directly passed to the S3 client.
-> This means you can also provide alternative authentication properties, such as [credentials](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html#constructor-property).
-
 #### `options.bucket`
 
 The bucket name.

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -32,16 +32,16 @@ npm install @tus/s3-store
 const {Server} = require('@tus/server')
 const {S3Store} = require('@tus/s3-store')
 
-const server = new Server({
-  path: '/files',
-  datastore: new S3Store({
+const s3Store = new S3Store({
+  partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MB,
+  s3ClientConfig: {
     bucket: process.env.AWS_BUCKET,
+    region: process.env.AWS_REGION,
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    region: process.env.AWS_REGION,
-    partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MB,
-  }),
+  },
 })
+const server = new Server({path: '/files', datastore: s3Store})
 // ...
 ```
 
@@ -93,20 +93,18 @@ const aws = require('aws-sdk')
 const {Server} = require('@tus/server')
 const {FileStore} = require('@tus/s3-store')
 
-const server = new Server({
-  path: '/files',
-  datastore: new S3Store({
-    bucket: 'bucket-name',
-    partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MB,
-    s3ClientConfig: {
-      region: 'eu-west-1',
-      credentials: new aws.ECSCredentials({
-        httpOptions: {timeout: 5000},
-        maxRetries: 10,
-      }),
-    },
-  }),
+const s3Store = new S3Store({
+  partSize: 8 * 1024 * 1024,
+  s3ClientConfig: {
+    bucket: process.env.AWS_BUCKET,
+    region: process.env.AWS_REGION,
+    credentials: new aws.ECSCredentials({
+      httpOptions: {timeout: 5000},
+      maxRetries: 10,
+    }),
+  },
 })
+const server = new Server({path: '/files', datastore: s3Store})
 // ...
 ```
 

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -25,7 +25,7 @@ type Options = {
   // but may increase it to not exceed the S3 10K parts limit.
   partSize?: number
   // Options to pass to the AWS S3 SDK.
-  s3Options: aws.S3.Types.ClientConfiguration
+  s3ClientConfig: aws.S3.Types.ClientConfiguration
 }
 
 type MetadataValue = {file: Upload; upload_id: string; tus_version: string}
@@ -72,11 +72,11 @@ export class S3Store extends DataStore {
 
   constructor(options: Options) {
     super()
-    const {bucket, partSize, s3Options} = options
+    const {bucket, partSize, s3ClientConfig} = options
     this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length']
     this.bucket = bucket
     this.preferredPartSize = partSize || 8 * 1024 * 1024
-    this.client = new aws.S3(s3Options)
+    this.client = new aws.S3(s3ClientConfig)
   }
 
   /**

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -24,7 +24,9 @@ type Options = {
   // The server calculates the optimal part size, which takes this size into account,
   // but may increase it to not exceed the S3 10K parts limit.
   partSize?: number
-} & aws.S3.Types.ClientConfiguration
+  // Options to pass to the AWS S3 SDK.
+  s3Options: aws.S3.Types.ClientConfiguration
+}
 
 type MetadataValue = {file: Upload; upload_id: string; tus_version: string}
 // Implementation (based on https://github.com/tus/tusd/blob/master/s3store/s3store.go)
@@ -70,12 +72,11 @@ export class S3Store extends DataStore {
 
   constructor(options: Options) {
     super()
-    const {bucket, partSize, ...rest} = options
+    const {bucket, partSize, s3Options} = options
     this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length']
     this.bucket = bucket
     this.preferredPartSize = partSize || 8 * 1024 * 1024
-    // TODO: why the old apiVersion?
-    this.client = new aws.S3({apiVersion: '2006-03-01', region: 'eu-west-1', ...rest})
+    this.client = new aws.S3(s3Options)
   }
 
   /**

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -18,14 +18,12 @@ function calcOffsetFromParts(parts?: aws.S3.Parts) {
 }
 
 type Options = {
-  // Name of the bucket.
-  bucket: string
   // The preferred part size for parts send to S3. Can not be lower than 5MB or more than 500MB.
   // The server calculates the optimal part size, which takes this size into account,
   // but may increase it to not exceed the S3 10K parts limit.
   partSize?: number
   // Options to pass to the AWS S3 SDK.
-  s3ClientConfig: aws.S3.Types.ClientConfiguration
+  s3ClientConfig: aws.S3.Types.ClientConfiguration & {bucket: string}
 }
 
 type MetadataValue = {file: Upload; upload_id: string; tus_version: string}
@@ -72,11 +70,12 @@ export class S3Store extends DataStore {
 
   constructor(options: Options) {
     super()
-    const {bucket, partSize, s3ClientConfig} = options
+    const {partSize, s3ClientConfig} = options
+    const {bucket, ...restS3ClientConfig} = s3ClientConfig
     this.extensions = ['creation', 'creation-with-upload', 'creation-defer-length']
     this.bucket = bucket
     this.preferredPartSize = partSize || 8 * 1024 * 1024
-    this.client = new aws.S3(s3ClientConfig)
+    this.client = new aws.S3(restS3ClientConfig)
   }
 
   /**


### PR DESCRIPTION
It's a bit odd to merge the tus store options with the S3 SDK client config options. The client config is also massive so it would pollute the types. Instead we now have a new options to pass to the S3 store: `s3ClientConfig`, which is directly passed to the SDK.