### PR TITLE
@tus/server: fix header exception when using a load balancer

### DIFF
--- a/packages/server/src/validators/RequestValidator.ts
+++ b/packages/server/src/validators/RequestValidator.ts
@@ -35,6 +35,14 @@ export const RequestValidator = {
     return false
   },
 
+  _invalidXForwardedHostHeader() {
+    return false
+  },
+
+  _invalidXForwardedProtoHeader(value: string) {
+    return !['http', 'https'].includes(value);
+  },
+
   _invalidTusVersionHeader(value: string) {
     // @ts-expect-error we can compare a literal
     return !TUS_VERSION.includes(value)

--- a/packages/server/src/validators/RequestValidator.ts
+++ b/packages/server/src/validators/RequestValidator.ts
@@ -40,7 +40,7 @@ export const RequestValidator = {
   },
 
   _invalidXForwardedProtoHeader(value: string) {
-    return !['http', 'https'].includes(value);
+    return !['http', 'https'].includes(value)
   },
 
   _invalidTusVersionHeader(value: string) {


### PR DESCRIPTION
I met conditions when Server cannot handle request. The reasons is that RequestValidator missing validation functions for 'X-Forwarded-Host' and 'X-Forwarded-Proto' headers.