### PR TITLE
@tus/server: handle non-ASCII file IDs

### DIFF
--- a/packages/server/src/handlers/BaseHandler.ts
+++ b/packages/server/src/handlers/BaseHandler.ts
@@ -30,6 +30,8 @@ export class BaseHandler extends EventEmitter {
   }
 
   generateUrl(req: http.IncomingMessage, id: string) {
+    id = encodeURIComponent(id)
+
     const forwarded = req.headers.forwarded as string | undefined
     const path = this.options.path === '/' ? '' : this.options.path
     // @ts-expect-error baseUrl type doesn't exist?
@@ -71,6 +73,6 @@ export class BaseHandler extends EventEmitter {
       return false
     }
 
-    return match[1]
+    return decodeURIComponent(match[1])
   }
 }

--- a/packages/server/test/BaseHandler.test.ts
+++ b/packages/server/test/BaseHandler.test.ts
@@ -58,4 +58,11 @@ describe('BaseHandler', () => {
 
     assert.equal(id, '1234')
   })
+
+  it('should handle URL-encoded ID', () => {
+    const req = {url: '/some/path/yeah/1234%205%23'} as http.IncomingMessage
+    const id = handler.getFileIdFromRequest(req)
+
+    assert.equal(id, '1234 5#')
+  })
 })


### PR DESCRIPTION
Properly encode `fileId` when composing URL and then decode when parsing. This allows user to use any naming function that is compatible with storage used. 