### PR TITLE
Fix demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,20 +118,20 @@ The tus protocol supports optional [extensions][]. Below is a table of the suppo
 Start the demo server using Local File Storage
 
 ```bash
-yarn workspace demo start
+yarn build && yarn demo
 ```
 
 Start up the demo server using AWS S3. The environment variables `AWS_BUCKET`,
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` need to be present.
 
 ```bash
-yarn workspace demo start:s3
+yarn build && yarn demo:s3
 ```
 
 Start up the demo server using Google Cloud Storage. A `keyfile.json` needs to be present in the root of the repository.
 
 ```bash
-yarn workspace demo start:gcs
+yarn build && yarn demo:gcs
 ```
 
 Then navigate to the demo ([localhost:1080](http://localhost:1080)) which uses [`tus-js-client`](https://github.com/tus/tus-js-client).

--- a/demo/server.js
+++ b/demo/server.js
@@ -59,7 +59,7 @@ const writeFile = (req, res) => {
   if (!filename.startsWith('/dist/')) {
     filename = '/demos/browser' + filename
   }
-  filename = path.join(process.cwd(), '/node_modules/tus-js-client', filename)
+  filename = path.join(process.cwd(), '../node_modules/tus-js-client', filename)
   fs.readFile(filename, 'binary', (err, file) => {
     if (err) {
       res.writeHead(500, {'Content-Type': 'text/plain'})


### PR DESCRIPTION
When running  `demo` command it was not working for me. First I did not build project as I expected that to be done automatically. Then there was error 404 because demo server could not find static files to serve (from `tus-js-client`).

- `yarn install && yarn demo` produced error `Cannot find module: <some_path>/index.js`. So I added instruction to build before run. 
- `yarn install && yarn build && yarn demo` returned error 404.

`yarn build` command could also be added to `package.json` file
```
    "demo": "yarn build && yarn workspace demo start",
    "demo:gcs": "yarn build && yarn workspace demo start:gcs",
    "demo:s3": "yarn build && yarn workspace demo start:s3",
```