### PR TITLE
Fix e2e test typecheking

### DIFF
--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -426,12 +426,12 @@ describe('EndToEnd', () => {
       it('can delete expired files', (done) => {
         server.datastore
           .deleteExpired()
-          .catch((error) => {
-            done(error)
-          })
           .then((deleted) => {
             assert.equal(deleted >= 1, true)
             done()
+          })
+          .catch((error) => {
+            done(error)
           })
       })
     })

--- a/test/package.json
+++ b/test/package.json
@@ -3,6 +3,7 @@
   "name": "test",
   "private": true,
   "scripts": {
+    "build": "tsc",
     "test": "mocha e2e.test.ts --timeout 40000 --exit --extension ts --require ts-node/register"
   },
   "dependencies": {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig.json",
   "extends": "tsconfig/tsconfig.json",
   "include": ["e2e.test.ts"],
-  "ts-node": {
-    "transpileOnly": true
+  "compilerOptions": {
+    "noEmit": true,
   }
 }


### PR DESCRIPTION
No type checking is performed on `e2e.test.ts` at build or test during CI or locally. 

This PR enables typescript type checking at build and test step and fixes compilation error that would happen with typescript 5.