### PR TITLE
@tus/s3-store: replace Underscores with Hyphens in Metadata Field Names

### DIFF
--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -22,7 +22,7 @@ export const HEADERS = [
 
 export const HEADERS_LOWERCASE = HEADERS.map((header) => {
   return header.toLowerCase()
-}) as Array<Lowercase<typeof HEADERS[number]>>
+}) as Array<Lowercase<(typeof HEADERS)[number]>>
 
 export const ALLOWED_HEADERS = HEADERS.join(', ')
 export const ALLOWED_METHODS = REQUEST_METHODS.join(', ')


### PR DESCRIPTION
Hello,

I am proposing a change to the metadata field naming convention used in the AWS SDK S3 operations. Specifically, I recommend replacing underscores `_` with hyphens `-`.

### Motivation
In compliance with RFC 7230, HTTP headers should not contain underscores. However, I've noticed that the current implementation uses underscores in the metadata field names, which subsequently form part of the headers. This has the potential to lead to compatibility issues when interacting with services that strictly follow the standards. One such example is Nginx, which by default, ignores headers containing underscores.

### Problem Description
When using the AWS SDK S3 to interact with S3-like services(minio) behind a proxy server (like Nginx), the service may return an error stating that "There were headers present in the request which were not signed". This is due to the headers with underscores being ignored, leading to discrepancies between the expected and actual headers.

### Proposed Solution
To avoid such compatibility issues, I suggest modifying the metadata field naming convention to use hyphens instead of underscores. This aligns better with widely accepted HTTP header practices and prevents potential compatibility issues with proxy servers or other services.

This proposed change should be largely transparent to users but would significantly improve the robustness and compatibility of the service.

Looking forward to your feedback.
