### PR TITLE
replace type-fest by raw typescript

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -38,7 +38,6 @@
     "supertest": "^6.3.2",
     "ts-node": "^10.9.1",
     "tsconfig": "*",
-    "type-fest": "^3.1.0",
     "typescript": "latest"
   },
   "engines": {

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -8,13 +8,12 @@ import {EVENTS, ERRORS} from '../constants'
 import type http from 'node:http'
 import type {ServerOptions} from '../types'
 import type {DataStore} from '../models'
-import type {SetRequired} from 'type-fest'
 
 const log = debug('tus-node-server:handlers:post')
 
 export class PostHandler extends BaseHandler {
   // Overriding the `BaseHandler` type. We always set `namingFunction` in the constructor.
-  options!: SetRequired<ServerOptions, 'namingFunction'>
+  options!: Required<Pick<ServerOptions, 'namingFunction'>> & Omit<ServerOptions, 'namingFunction'>
 
   constructor(store: DataStore, options: ServerOptions) {
     if (options.namingFunction && typeof options.namingFunction !== 'function') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,7 +344,6 @@ __metadata:
     supertest: ^6.3.2
     ts-node: ^10.9.1
     tsconfig: "*"
-    type-fest: ^3.1.0
     typescript: latest
   languageName: unknown
   linkType: soft
@@ -3886,13 +3885,6 @@ __metadata:
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
   checksum: 4fb3272df21ad1c552486f8a2f8e115c09a521ad7a8db3d56d53718d0c907b62c6e9141ba5f584af3f6830d0872c521357e512381f24f7c44acae583ad517d73
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^3.1.0":
-  version: 3.3.0
-  resolution: "type-fest@npm:3.3.0"
-  checksum: 6f260466dd1847048bca4481412f39c32fbb69abbe6daf1ead67e682529adfe8ab8f150a9937eddd065fa544eaf92c15e35ebad0f45f46feadcfbd3a87ae5a2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We have some issue in our project with different versions of type-fest, and we noticed it is only used once in the whole project.

I rewrote the usage in typescript and got rid of the dependency.