### PR TITLE
@tus/server: do not emit chunkFinished on error

### DIFF
--- a/packages/server/src/models/StreamSplitter.ts
+++ b/packages/server/src/models/StreamSplitter.ts
@@ -85,17 +85,20 @@ export class StreamSplitter extends stream.Writable {
     this.currentChunkSize += chunk.length
   }
 
-  async _finishChunk(): Promise<void> {
+  async _finishChunk(err?: Error): Promise<void> {
     if (this.fileHandle === null) {
       return
     }
 
     await this.fileHandle.close()
 
-    this.emit('chunkFinished', {
-      path: this.currentChunkPath,
-      size: this.currentChunkSize,
-    })
+    if (!err) {
+      this.emit('chunkFinished', {
+        path: this.currentChunkPath,
+        size: this.currentChunkSize,
+      })
+    }
+
     this.currentChunkPath = null
     this.fileHandle = null
     this.currentChunkSize = 0


### PR DESCRIPTION
Related to https://github.com/tus/tus-node-server/issues/444 

If an error occurs during the write stream, we don't want to broadcast the chunkFinished event.
This should fix potential race conditions