### PR TITLE
@tus/s3-store: fix min part size condition & offset race condition

### DIFF
--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -257,8 +257,10 @@ export class S3Store extends DataStore {
             const readable = fs.createReadStream(path)
             readable.on('error', reject)
             if (partSize >= this.minPartSize || isFinalChunk) {
-              await this.uploadPart(metadata, readable, partNumber)
+              // The stream splitter may be faster than we are able to upload to S3
+              // so we increment the offset before uploading the part.
               offset += partSize
+              await this.uploadPart(metadata, readable, partNumber)
             } else {
               await this.uploadIncompletePart(incompletePartId, readable)
             }

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -256,7 +256,7 @@ export class S3Store extends DataStore {
 
             const readable = fs.createReadStream(path)
             readable.on('error', reject)
-            if (partSize > this.minPartSize || isFinalChunk) {
+            if (partSize >= this.minPartSize || isFinalChunk) {
               await this.uploadPart(metadata, readable, partNumber)
               offset += partSize
             } else {


### PR DESCRIPTION
Fixes #415

- if the current part is exactly the minimum part size, then that should also be allowed, not minimum + 1
- fix race condition in which the stream splitter is faster than uploading to S3, resulting the offset not being updated in time before the next chunk is handled.