### PR TITLE
@tus/gcs-store: ensure metadata is (re)encoded

### DIFF
--- a/packages/gcs-store/index.ts
+++ b/packages/gcs-store/index.ts
@@ -83,7 +83,7 @@ export class GCSStore extends DataStore {
               size: upload.size,
               sizeIsDeferred: `${upload.sizeIsDeferred}`,
               offset,
-              metadata: upload.metadata,
+              metadata: JSON.stringify(upload.metadata),
             },
           },
         }


### PR DESCRIPTION
There appears to be a silent loss of the `metadata.metadata` on write. Adding `JSON.stringify` as used in create https://github.com/tus/tus-node-server/blob/main/packages/gcs-store/index.ts#L44 fixed the issue I was seeing.

Sorry not added a test but not had a chance to get it all set up. The `metadata.metadata` is there on create but will be removed as the file is written. Other data such as offset is retained correctly
```
const TEST_METADATA = 'filetype dmlkZW8vbXA0,filename dGVzdC5tcDQ='
```
```
gcloud storage objects describe gs://{bucket}/8614d69d16b7344cd24e530dfd20672c
bucket: {bucket}
crc32c: cuffvA==
etag: CPysvYzMmIEDEAE=
generation: '1694092967761532'
id: {bucket}/8614d69d16b7344cd24e530dfd20672c/1694092967761532
kind: storage#object
md5Hash: ILjxSjUwj4okFluJpikGmQ==
mediaLink: https://storage.googleapis.com/download/storage/v1/b/{bucket}/o/8614d69d16b7344cd24e530dfd20672c?generation=1694092967761532&alt=media
metadata:
  metadata: '{"filetype":"video/mp4","filename":"test.mp4"}'
  offset: '0'
  size: '960244'
  sizeIsDeferred: 'false'
  tus_version: 1.0.0
metageneration: '1'
```