### PR TITLE
@tus/s3-store: Fix offset calculation for uploads with incomplete part

### DIFF
--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -486,7 +486,7 @@ export class S3Store extends DataStore {
       throw error
     }
 
-    const incompletePart = await this.getIncompletePart(this.partKey(id))
+    const incompletePart = await this.getIncompletePart(this.partKey(id, true))
 
     return new Upload({
       id,

--- a/packages/s3-store/test.ts
+++ b/packages/s3-store/test.ts
@@ -7,7 +7,7 @@ import sinon from 'sinon'
 
 import {S3Store} from './'
 import * as shared from '../../test/stores.test'
-import {Upload} from '@tus/server'
+import {Upload, Uid} from '@tus/server'
 
 const fixturesPath = path.resolve('../', '../', 'test', 'fixtures')
 const storePath = path.resolve('../', '../', 'test', 'output')
@@ -77,7 +77,7 @@ describe('S3DataStore', function () {
     const size = 4096
     const incompleteSize = 1024
     const upload = new Upload({
-      id: 'incomplete-part-test-1',
+      id: `incomplete-part-test-${Uid.rand()}`,
       size: size + incompleteSize,
       offset: 0,
     })

--- a/packages/s3-store/test.ts
+++ b/packages/s3-store/test.ts
@@ -72,6 +72,38 @@ describe('S3DataStore', function () {
     assert.equal(offset, size + incompleteSize)
   })
 
+  it('store shuld return proper offset when incomplete part exists', async function () {
+    const store = this.datastore
+    const size = 4096
+    const incompleteSize = 1024
+    const upload = new Upload({
+      id: 'incomplete-part-test-1',
+      size: size + incompleteSize,
+      offset: 0,
+    })
+
+    await store.create(upload)
+
+    {
+      const {offset} = await store.getUpload(upload.id)
+      assert.equal(offset, 0)
+    }
+
+    {
+      const offset = await store.write(
+        Readable.from(Buffer.alloc(incompleteSize)),
+        upload.id,
+        upload.offset
+      )
+      assert.equal(offset, incompleteSize)
+    }
+
+    {
+      const {offset} = await store.getUpload(upload.id)
+      assert.equal(offset, incompleteSize)
+    }
+  })
+
   it('should process chunk size of exactly the min size', async function () {
     this.datastore.minPartSize = 1024 * 1024 * 5
     const store = this.datastore


### PR DESCRIPTION
This PR fixes incorrect `Upload-Offset` on HEAD request for uploads with incomplete part. 

First commit is the actual fix, second is non-mandatory refactor which makes `id` parameter having a consistent meaning for all functions in this class. Before this change `id` sometimes meant `<upload-id>`, but when working with incomplete parts it was expected to be `<upload-id>.part`.
Handling of suffix `.part` is moved into all functions that work directly with incomplete parts.

Note: this PR will conflict with #492 because of this second commit. I'll fix that when either is merged.