### PR TITLE
@tus/s3-store: finalize incomplete parts

### DIFF
--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -504,7 +504,13 @@ export class S3Store extends DataStore {
 
     if (metadata.file.size === newOffset) {
       try {
+        // If no parts exist yet, then the incomplete part needs to be completed
+        const incompletePart = await this.getIncompletePart(id)
+        if (incompletePart) {
+          await this.uploadPart(metadata, incompletePart, nextPartNumber)
+        }
         const parts = await this.retrieveParts(id)
+
         await this.finishMultipartUpload(metadata, parts as Array<AWS.Part>)
         this.clearCache(id)
       } catch (error) {


### PR DESCRIPTION
Fixes #501 

When an upload completes with only a single incomplete part having been uploaded, `uploadPart` has never run to establish the first part.

As a result, `parts` are empty, and `inalizeMultipartUpload` fails with a `500`.

### Fix

Wasn't sure of the bets way to accomplish this, since the final step is an empty `PATCH` with just `Upload-Length` header, so the main `processUpload` routine that normally calls `uploadPart` and `uploadIncompletePart` will not run a final time -- so I performed the final `uploadPart` as part of the `write` procedure, ensuring the first `part` will always exist for `finishMultipartUpload` to run.