### PR TITLE
@tus/s3-store: Fix invalid chunk size for uploads with deferred length

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -29,7 +29,7 @@ const stores = {
     assert.ok(process.env.AWS_REGION, 'environment variable `AWS_REGION` must be set')
 
     return new S3Store({
-      partSize: 8 * 1024 * 1024, // each uploaded part will have ~8MB,
+      partSize: 8 * 1024 * 1024, // each uploaded part will have ~8MiB,
       s3ClientConfig: {
         bucket: process.env.AWS_BUCKET,
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -61,7 +61,7 @@ The bucket name.
 
 #### `options.partSize`
 
-The preferred part size for parts send to S3. Can not be lower than 5MB or more than 500MB.
+The preferred part size for parts send to S3. Can not be lower than 5MB or more than 5GB.
 The server calculates the optimal part size, which takes this size into account,
 but may increase it to not exceed the S3 10K parts limit.
 

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -33,7 +33,7 @@ const {Server} = require('@tus/server')
 const {S3Store} = require('@tus/s3-store')
 
 const s3Store = new S3Store({
-  partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MB,
+  partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MiB,
   s3ClientConfig: {
     bucket: process.env.AWS_BUCKET,
     region: process.env.AWS_REGION,
@@ -61,7 +61,7 @@ The bucket name.
 
 #### `options.partSize`
 
-The preferred part size for parts send to S3. Can not be lower than 5MB or more than 5GB.
+The preferred part size for parts send to S3. Can not be lower than 5MiB or more than 5GiB.
 The server calculates the optimal part size, which takes this size into account,
 but may increase it to not exceed the S3 10K parts limit.
 

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -269,8 +269,6 @@ export class S3Store extends DataStore {
     let bytesUploaded = 0
     let currentChunkNumber = 0
 
-    console.log("this.calcOptimalPartSize(size)", this.calcOptimalPartSize(size));
-
     const splitterStream = new StreamSplitter({
       chunkSize: this.calcOptimalPartSize(size),
       directory: os.tmpdir(),

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -18,7 +18,7 @@ function calcOffsetFromParts(parts?: Array<AWS.Part>) {
 }
 
 type Options = {
-  // The preferred part size for parts send to S3. Can not be lower than 5MB or more than 500MB.
+  // The preferred part size for parts send to S3. Can not be lower than 5MB or more than 5GB.
   // The server calculates the optimal part size, which takes this size into account,
   // but may increase it to not exceed the S3 10K parts limit.
   partSize?: number

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -18,7 +18,7 @@ function calcOffsetFromParts(parts?: Array<AWS.Part>) {
 }
 
 type Options = {
-  // The preferred part size for parts send to S3. Can not be lower than 5MB or more than 5GB.
+  // The preferred part size for parts send to S3. Can not be lower than 5MiB or more than 5GiB.
   // The server calculates the optimal part size, which takes this size into account,
   // but may increase it to not exceed the S3 10K parts limit.
   partSize?: number

--- a/packages/s3-store/test.ts
+++ b/packages/s3-store/test.ts
@@ -29,7 +29,6 @@ describe('S3DataStore', function () {
           secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY as string,
         },
         region: process.env.AWS_REGION,
-        endpoint: process.env.AWS_HOST,
       },
     })
   })

--- a/packages/s3-store/test.ts
+++ b/packages/s3-store/test.ts
@@ -21,7 +21,7 @@ describe('S3DataStore', function () {
   })
   beforeEach(function () {
     this.datastore = new S3Store({
-      partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MB,
+      partSize: 8 * 1024 * 1024, // Each uploaded part will have ~8MiB,
       s3ClientConfig: {
         bucket: process.env.AWS_BUCKET as string,
         credentials: {
@@ -29,6 +29,7 @@ describe('S3DataStore', function () {
           secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY as string,
         },
         region: process.env.AWS_REGION,
+        endpoint: process.env.AWS_HOST,
       },
     })
   })
@@ -115,8 +116,8 @@ describe('S3DataStore', function () {
 
   it('upload as multipart upload when incomplete part grows beyond minimal part size', async function () {
     const store = this.datastore
-    const size = 10 * 1024 * 1024 // 10MB
-    const incompleteSize = 2 * 1024 * 1024 // 2MB
+    const size = 10 * 1024 * 1024 // 10MiB
+    const incompleteSize = 2 * 1024 * 1024 // 2MiB
     const getIncompletePart = sinon.spy(store, 'getIncompletePart')
     const uploadIncompletePart = sinon.spy(store, 'uploadIncompletePart')
     const uploadPart = sinon.spy(store, 'uploadPart')

--- a/packages/s3-store/test.ts
+++ b/packages/s3-store/test.ts
@@ -36,8 +36,8 @@ describe('S3DataStore', function () {
 
   it('calculated part size for deferred lenght should be finite', async function () {
     const store = this.datastore
-    
-    assert.strictEqual(Number.isFinite(store.calcOptimalPartSize(undefined)), true);
+
+    assert.strictEqual(Number.isFinite(store.calcOptimalPartSize(undefined)), true)
   })
 
   it('should correctly prepend a buffer to a file', async function () {

--- a/packages/s3-store/test.ts
+++ b/packages/s3-store/test.ts
@@ -33,6 +33,12 @@ describe('S3DataStore', function () {
     })
   })
 
+  it('calculated part size for deferred lenght should be finite', async function () {
+    const store = this.datastore
+    
+    assert.strictEqual(Number.isFinite(store.calcOptimalPartSize(undefined)), true);
+  })
+
   it('should correctly prepend a buffer to a file', async function () {
     const p = path.resolve(fixturesPath, 'foo.txt')
     await fs.writeFile(p, 'world!')


### PR DESCRIPTION
This PR fixes #503.

When upload size is not known current calculated chunk size is `NaN` which causes request to be cached to disk without upper limit. Later it would be uploaded as part. If request was larger than 5GB (max size of single part) the upload would fail. 

This fix assumes maximum possible file size (5TiB) when calculating chunk size. Calculated chunk size for this size is `~524MiB`.