### PR TITLE
@tus/server: Split to multiple chunks on large incoming buffer

### DIFF
--- a/packages/server/src/models/StreamSplitter.ts
+++ b/packages/server/src/models/StreamSplitter.ts
@@ -43,19 +43,20 @@ export class StreamSplitter extends stream.Writable {
       if (this.fileHandle === null) {
         await this._newChunk()
       }
+      
+      let overflow = this.currentChunkSize + chunk.length - this.chunkSize
 
-      const overflow = this.currentChunkSize + chunk.length - this.chunkSize
       // The current chunk will be more than our defined part size if we would
       // write all of it to disk.
-      if (overflow > 0) {
+      while (overflow > 0) {
         // Only write to disk the up to our defined part size.
-        await this._writeChunk(chunk.slice(0, chunk.length - overflow))
+        await this._writeChunk(chunk.subarray(0, chunk.length - overflow))
         await this._finishChunk()
+        
         // We still have some overflow left, so we write it to a new chunk.
         await this._newChunk()
-        await this._writeChunk(chunk.slice(chunk.length - overflow, chunk.length))
-        callback(null)
-        return
+        chunk = chunk.subarray(chunk.length - overflow, chunk.length)
+        overflow = this.currentChunkSize + chunk.length - this.chunkSize
       }
 
       // The chunk is smaller than our defined part size so we can just write it to disk.

--- a/packages/server/src/models/StreamSplitter.ts
+++ b/packages/server/src/models/StreamSplitter.ts
@@ -43,7 +43,7 @@ export class StreamSplitter extends stream.Writable {
       if (this.fileHandle === null) {
         await this._newChunk()
       }
-      
+
       let overflow = this.currentChunkSize + chunk.length - this.chunkSize
 
       // The current chunk will be more than our defined part size if we would
@@ -52,7 +52,7 @@ export class StreamSplitter extends stream.Writable {
         // Only write to disk the up to our defined part size.
         await this._writeChunk(chunk.subarray(0, chunk.length - overflow))
         await this._finishChunk()
-        
+
         // We still have some overflow left, so we write it to a new chunk.
         await this._newChunk()
         chunk = chunk.subarray(chunk.length - overflow, chunk.length)

--- a/packages/server/test/StreamSplitter.test.ts
+++ b/packages/server/test/StreamSplitter.test.ts
@@ -29,7 +29,7 @@ describe('StreamSplitter', () => {
 
   it('should split to multiple chunks when single buffer exceeds chunk size', async () => {
     const optimalChunkSize = 1024
-    const expectedChunks = 7;
+    const expectedChunks = 7
 
     const readStream = Readable.from([Buffer.alloc(expectedChunks * optimalChunkSize)])
 
@@ -38,11 +38,13 @@ describe('StreamSplitter', () => {
     const splitterStream = new StreamSplitter({
       chunkSize: optimalChunkSize,
       directory: os.tmpdir(),
-    }).on('chunkStarted', () => {
-      chunksStarted++
-    }).on('chunkFinished', () => {
-      chunksFinished++
     })
+      .on('chunkStarted', () => {
+        chunksStarted++
+      })
+      .on('chunkFinished', () => {
+        chunksFinished++
+      })
 
     await stream.pipeline(readStream, splitterStream)
 


### PR DESCRIPTION
When handling incoming request, each buffer length is 64kb which `StreamSplitter` can handle without issues.

But in tests we might create buffers much larger than single part size, which might not be split as expected.

Works:
`const readStream = Readable.from(Buffer.alloc(expectedChunks * optimalChunkSize))`

Doesn't work:
`const readStream = Readable.from(`**`[`**`Buffer.alloc(expectedChunks * optimalChunkSize)`**`]`**`)`