### PR TITLE
@tus/server: add upload id to `onIncomingRequest`

### DIFF
--- a/packages/server/src/handlers/DeleteHandler.ts
+++ b/packages/server/src/handlers/DeleteHandler.ts
@@ -10,6 +10,10 @@ export class DeleteHandler extends BaseHandler {
       throw ERRORS.FILE_NOT_FOUND
     }
 
+    if (this.options.onIncomingRequest) {
+      await this.options.onIncomingRequest(req, res, id)
+    }
+
     await this.store.remove(id)
     const writtenRes = this.write(res, 204, {})
     this.emit(EVENTS.POST_TERMINATE, req, writtenRes, id)

--- a/packages/server/src/handlers/GetHandler.ts
+++ b/packages/server/src/handlers/GetHandler.ts
@@ -35,6 +35,10 @@ export class GetHandler extends BaseHandler {
       throw ERRORS.FILE_NOT_FOUND
     }
 
+    if (this.options.onIncomingRequest) {
+      await this.options.onIncomingRequest(req, res, id)
+    }
+
     const stats = await this.store.getUpload(id)
     if (!stats || stats.offset !== stats.size) {
       throw ERRORS.FILE_NOT_FOUND

--- a/packages/server/src/handlers/HeadHandler.ts
+++ b/packages/server/src/handlers/HeadHandler.ts
@@ -12,6 +12,10 @@ export class HeadHandler extends BaseHandler {
       throw ERRORS.FILE_NOT_FOUND
     }
 
+    if (this.options.onIncomingRequest) {
+      await this.options.onIncomingRequest(req, res, id)
+    }
+
     const file = await this.store.getUpload(id)
 
     // If a Client does attempt to resume an upload which has since

--- a/packages/server/src/handlers/PatchHandler.ts
+++ b/packages/server/src/handlers/PatchHandler.ts
@@ -30,6 +30,10 @@ export class PatchHandler extends BaseHandler {
       throw ERRORS.INVALID_CONTENT_TYPE
     }
 
+    if (this.options.onIncomingRequest) {
+      await this.options.onIncomingRequest(req, res, id)
+    }
+
     const upload = await this.store.getUpload(id)
 
     // If a Client does attempt to resume an upload which has since

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -68,6 +68,10 @@ export class PostHandler extends BaseHandler {
       }
     }
 
+    if (this.options.onIncomingRequest) {
+      await this.options.onIncomingRequest(req, res, id)
+    }
+
     const upload = new Upload({
       id,
       size: upload_length ? Number.parseInt(upload_length, 10) : undefined,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -153,12 +153,6 @@ export class Server extends EventEmitter {
       return this.write(res, status_code, body)
     }
 
-    try {
-      await this.options.onIncomingRequest?.(req, res)
-    } catch (err) {
-      return onError(err)
-    }
-
     if (req.method === 'GET') {
       const handler = this.handlers.GET
       return handler.send(req, res).catch(onError)

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -34,7 +34,8 @@ export type ServerOptions = {
   ) => Promise<http.ServerResponse>
   onIncomingRequest?: (
     req: http.IncomingMessage,
-    res: http.ServerResponse
+    res: http.ServerResponse,
+    uploadId: string
   ) => Promise<void>
 }
 


### PR DESCRIPTION
This PR makes the `onIncomingRequest` hook more useful by adding the `uploadId` as the 3rd parameter.
99% of cases you'd like to use this hook to perform authorization logic. However is always very common to allow check for permission specifically for certain upload-id.

For example:

- Can this user add chunks to this upload?
- Can this user view this asset?

By adding the upload-id we can implement custom logic on a per asset basis