### PR TITLE
feat: Custom error handler

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -147,9 +147,20 @@ export class Server extends EventEmitter {
       req.method = (req.headers['x-http-method-override'] as string).toUpperCase()
     }
 
-    const onError = (error: {status_code?: number; body?: string; message: string}) => {
+    const onError = async (error: {
+      status_code?: number
+      body?: string
+      message: string
+    }) => {
       const status_code = error.status_code || ERRORS.UNKNOWN_ERROR.status_code
       const body = error.body || `${ERRORS.UNKNOWN_ERROR.body}${error.message || ''}\n`
+
+      if (this.options.onResponseError) {
+        const write = ({status_code, body}: {status_code: number; body: string}) => {
+          return this.write(res, status_code, body)
+        }
+        return this.options.onResponseError(req, res, {status_code, body}, write)
+      }
       return this.write(res, status_code, body)
     }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -36,6 +36,12 @@ export type ServerOptions = {
     req: http.IncomingMessage,
     res: http.ServerResponse
   ) => Promise<void>
+  onResponseError?: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    err: {status_code: number; body: string},
+    write: (error: {status_code: number; body: string}) => http.ServerResponse
+  ) => Promise<http.ServerResponse> | http.ServerResponse
 }
 
 export type RouteHandler = (req: http.IncomingMessage, res: http.ServerResponse) => void


### PR DESCRIPTION
This PR introduces an optional onErrorResponse hook which allows to do useful things when an error occurs.

Example usage:

```ts
new Server({
 ...
 onErrorResponse: async (req, res, error, write) => {
   return write(error)
 }
})