### PR TITLE
@tus/server: allow passing custom headers

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -68,6 +68,10 @@ Return a relative URL as the `Location` header to the client (`boolean`).
 
 Allow `Forwarded`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers to override the `Location` header returned by the server (`boolean`).
 
+#### `options.allowHeaders`
+
+Whitelists custom headers sent in `Access-Control-Allow-Headers` in OPTIONS requests, useful when sending custom headers in TUS requests (`string[]`)
+
 #### `options.namingFunction`
 
 Control how you want to name files (`(req) => string`)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -68,9 +68,9 @@ Return a relative URL as the `Location` header to the client (`boolean`).
 
 Allow `Forwarded`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers to override the `Location` header returned by the server (`boolean`).
 
-#### `options.allowHeaders`
+#### `options.allowedHeaders`
 
-Whitelists custom headers sent in `Access-Control-Allow-Headers` in OPTIONS requests, useful when sending custom headers in TUS requests (`string[]`)
+Additional headers sent in `Access-Control-Allow-Headers` (`string[]`).
 
 #### `options.namingFunction`
 

--- a/packages/server/src/handlers/OptionsHandler.ts
+++ b/packages/server/src/handlers/OptionsHandler.ts
@@ -1,5 +1,5 @@
 import {BaseHandler} from './BaseHandler'
-import {ALLOWED_METHODS, ALLOWED_HEADERS, MAX_AGE} from '../constants'
+import {ALLOWED_METHODS, MAX_AGE, HEADERS} from '../constants'
 
 import type http from 'node:http'
 
@@ -7,8 +7,10 @@ import type http from 'node:http'
 // the Tus-Version header. It MAY include the Tus-Extension and Tus-Max-Size headers.
 export class OptionsHandler extends BaseHandler {
   async send(_: http.IncomingMessage, res: http.ServerResponse) {
+    const allowedHeaders = [...HEADERS, ...(this.options.allowedHeaders ?? [])]
+
     res.setHeader('Access-Control-Allow-Methods', ALLOWED_METHODS)
-    res.setHeader('Access-Control-Allow-Headers', ALLOWED_HEADERS)
+    res.setHeader('Access-Control-Allow-Headers', allowedHeaders.join(', '))
     res.setHeader('Access-Control-Max-Age', MAX_AGE)
     if (this.store.extensions.length > 0) {
       res.setHeader('Tus-Extension', this.store.extensions.join(','))

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -10,6 +10,8 @@ export type ServerOptions = {
   // Allow `Forwarded`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers
   // to override the `Location` header returned by the server.
   respectForwardedHeaders?: boolean
+  // adds custom headers sent in `Access-Control-Allow-Headers`.
+  allowedHeaders?: string[]
   // Control how you want to name files.
   // It is important to make these unique to prevent data loss. Only use it if you really need to.
   // Default uses `crypto.randomBytes(16).toString('hex')`.

--- a/packages/server/test/Server.test.ts
+++ b/packages/server/test/Server.test.ts
@@ -145,6 +145,19 @@ describe('Server', () => {
         })
     })
 
+    it('OPTIONS should return returns custom headers in Access-Control-Allow-Headers', (done) => {
+      server.options.allowedHeaders = ['Custom-Header']
+
+      request(listener)
+        .options('/')
+        .expect(204, '', (err, res) => {
+          res.headers.should.have.property('access-control-allow-headers')
+          res.headers['access-control-allow-headers'].should.containEql('Custom-Header')
+          server.options.allowedHeaders = []
+          done(err)
+        })
+    })
+
     it('HEAD should 404 non files', (done) => {
       request(listener)
         .head('/')


### PR DESCRIPTION
Currently, the list of allowed headers is hard-coded and there is no way to add custom headers if not overwriting the entire OptionHandler.

This PR allows to whitelisting of additional custom headers that can be passed on OPTION responses to pass CORS

```ts
new Server({
 allowHeaders: ['X-Header-1', 'X-Header-2']
})
```