### PR TITLE
Feat: onErrorResponse hook

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -147,9 +147,22 @@ export class Server extends EventEmitter {
       req.method = (req.headers['x-http-method-override'] as string).toUpperCase()
     }
 
-    const onError = (error: {status_code?: number; body?: string; message: string}) => {
-      const status_code = error.status_code || ERRORS.UNKNOWN_ERROR.status_code
-      const body = error.body || `${ERRORS.UNKNOWN_ERROR.body}${error.message || ''}\n`
+    const onError = async (error: {
+      status_code?: number
+      body?: string
+      message: string
+    }) => {
+      let status_code = error.status_code || ERRORS.UNKNOWN_ERROR.status_code
+      let body = error.body || `${ERRORS.UNKNOWN_ERROR.body}${error.message || ''}\n`
+
+      if (this.options.onResponseError) {
+        const errorMapping = await this.options.onResponseError(req, res, error as Error)
+        if (errorMapping) {
+          status_code = errorMapping.status_code
+          body = errorMapping.body
+        }
+      }
+
       return this.write(res, status_code, body)
     }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -36,6 +36,14 @@ export type ServerOptions = {
     req: http.IncomingMessage,
     res: http.ServerResponse
   ) => Promise<void>
+  onResponseError?: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    err: Error | {status_code: number; body: string}
+  ) =>
+    | Promise<{status_code: number; body: string} | void>
+    | {status_code: number; body: string}
+    | void
 }
 
 export type RouteHandler = (req: http.IncomingMessage, res: http.ServerResponse) => void


### PR DESCRIPTION
This PR replaces https://github.com/tus/tus-node-server/pull/518 in favour of a new approach.

A legitimate use case for this hook which I think is worth considering is:

- Custom logging. In the PR you mentioned above doesn't really solve the issue because we might want to send the error somewhere in Sentry or in any error reporter of choice. Having this hook would make it possible to do just that.

- Centralizing the mapping of application-specific errors to Tus HTTP errors.
This use case I think is quite important since application-specific errors can be thrown in many different places not only on onUploadCreate , onUploadFinish but potentially in all the events hooks emitted as well in custom Locks implementations.

By centralising the mapping of error handling we don't need to try/catch everywhere and do the mapping in place, this allows for better maintainability in the long run.

I have changed the implementation slightly from the original PR and now the onErrorResponse doesn't actually allow to write the response but can be used as follows:

new Server({
 ...
 onErrorResponse: async (req, res, error) => {
   await customErrorReporter.error(error)
   
   if (error instanceof CustomError) {
      return { status_code: error.statusCode, body: error.message }
   }
 }
})

overall is a neat way to keep things tidy and centralised