### PR TITLE
@tus/s3-store: allow passing cache-control parameter in metadata

### DIFF
--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -477,6 +477,10 @@ export class S3Store extends DataStore {
       request.ContentType = upload.metadata.contentType
     }
 
+    if (upload.metadata?.cacheControl) {
+      request.CacheControl = upload.metadata.cacheControl
+    }
+
     upload.creation_date = new Date().toISOString()
 
     const res = await this.client.createMultipartUpload(request)


### PR DESCRIPTION
Tiny PR to allow setting the `CacheControl` header on the s3-store if the metadata field `cacheControl` is provided.
Similarly to how we handle `contentType` 