### PR TITLE
@tus/server: remove useless req.baseUrl & clarify docs

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -78,17 +78,47 @@ Allow `Forwarded`, `X-Forwarded-Proto`, and `X-Forwarded-Host` headers to overri
 Additional headers sent in `Access-Control-Allow-Headers` (`string[]`).
 
 #### `options.generateUrl`
-Control how the upload url is generated (`(req, { proto, host, baseUrl, path, id }) => string)`)
+
+Control how the upload URL is generated (`(req, { proto, host, path, id }) => string)`)
+
+This only changes the upload URL (`Location` header).
+If you also want to change the file name in storage use `namingFunction`.
+Returning `prefix-1234` in `namingFunction` means the `id` argument in `generateUrl` is `prefix-1234`.
+
+```js
+function generateUrl(req, {proto, host, path, id}) {
+  const prefix = getPrefixForUser(req) // your custom logic
+  return `${proto}://${host}${path}/${prefix}/${id}?query=param`
+},
+```
+
+> [!NOTE] > `@tus/server` expects everything after the last `/` to be the upload id.
+> If you change that you have to use `getFileIdFromRequest` as well.
 
 #### `options.getFileIdFromRequest`
+
 Control how the Upload-ID is extracted from the request (`(req) => string | void`)
 
 #### `options.namingFunction`
 
 Control how you want to name files (`(req) => string`)
 
+In `@tus/server`, the upload ID in the URL is the same as the file name.
+This means using a custom `namingFunction` will return a different `Location` header for uploading
+and result in a different file name in storage.
+
 It is important to make these unique to prevent data loss. Only use it if you need to.
 Default uses `crypto.randomBytes(16).toString('hex')`.
+
+```js
+function namingFunction(req) {
+  const prefix = getPrefixForUser(req) // your custom logic
+  return `${prefix}-${crypto.randomBytes(16).toString('hex')}`
+},
+```
+
+> [!CAUTION]
+> You can not use slashes (`/`) in your name.
 
 #### `disableTerminationForFinishedUploads`
 
@@ -358,31 +388,30 @@ Access control is opinionated and can be done in different ways.
 This example is psuedo-code for what it could look like with JSON Web Tokens.
 
 ```js
-const { Server } = require("@tus/server");
+const {Server} = require('@tus/server')
 // ...
 
 const server = new Server({
   // ..
   async onIncomingRequest(req, res) {
-    const token = req.headers.authorization;
+    const token = req.headers.authorization
 
     if (!token) {
-      throw { status_code: 401, body: 'Unauthorized' }
+      throw {status_code: 401, body: 'Unauthorized'}
     }
 
     try {
       const decodedToken = await jwt.verify(token, 'your_secret_key')
       req.user = decodedToken
     } catch (error) {
-      throw { status_code: 401, body: 'Invalid token' }
+      throw {status_code: 401, body: 'Invalid token'}
     }
 
     if (req.user.role !== 'admin') {
-      throw { status_code: 403, body: 'Access denied' }
+      throw {status_code: 403, body: 'Access denied'}
     }
   },
-});
-
+})
 ```
 
 ## Types

--- a/packages/server/src/handlers/BaseHandler.ts
+++ b/packages/server/src/handlers/BaseHandler.ts
@@ -39,8 +39,6 @@ export class BaseHandler extends EventEmitter {
   }
 
   generateUrl(req: http.IncomingMessage, id: string) {
-    // @ts-expect-error req.baseUrl does exist
-    const baseUrl = req.baseUrl ?? ''
     const path = this.options.path === '/' ? '' : this.options.path
 
     if (this.options.generateUrl) {
@@ -50,8 +48,6 @@ export class BaseHandler extends EventEmitter {
       return this.options.generateUrl(req, {
         proto,
         host,
-        // @ts-expect-error we can pass undefined
-        baseUrl: req.baseUrl,
         path: path,
         id,
       })
@@ -59,12 +55,12 @@ export class BaseHandler extends EventEmitter {
 
     // Default implementation
     if (this.options.relativeLocation) {
-      return `${baseUrl}${path}/${id}`
+      return `${path}/${id}`
     }
 
     const {proto, host} = this.extractHostAndProto(req)
 
-    return `${proto}://${host}${baseUrl}${path}/${id}`
+    return `${proto}://${host}${path}/${id}`
   }
 
   getFileIdFromRequest(req: http.IncomingMessage) {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -41,7 +41,7 @@ export type ServerOptions = {
    */
   generateUrl?: (
     req: http.IncomingMessage,
-    options: {proto: string; host: string; baseUrl: string; path: string; id: string}
+    options: {proto: string; host: string; path: string; id: string}
   ) => string
 
   /**


### PR DESCRIPTION
Resolves https://github.com/tus/tus-node-server/issues/457#issuecomment-1879889301

- Remove `req.baseUrl`, which was `ts-ignore`'d, from `generateUrl`. This is always `undefined` and only exists in Express.js. From a type perspective it's a breaking change, but since we always passed `undefined` and removing the type means it's still `undefined` so it's practically speaking the same.
- Clarify docs on `generateUrl`, `getFileIdFromRequest`, and `namingFunction`. This is a bit awkward and it seems we didn't think about this enough in #515. Let me explain:

I thought `generateUrl` supersedes `namingFunction`, as instead of only generating an ID we now do the entire URL. Except `generateUrl` only changes the returned `Location` header, while we used to have the principle of upload ID mapping to the file name in storage. So if you return an entirely different ID in `generateUrl`, the default of `namingFunction` is the name written to storage. If you define `namingFunction`, then that becomes the `id` argument in `generateUrl`. This is a bit of an unobvious and brittle relationship. 

Ideally, `namingFunction` is deprecated and the ID of `generateUrl` is used for creation in stores too. But the problem is `generateUrl` already expects the upload ID as the second argument.

Since we likely can't solve this without a breaking change I made this PR to improve the docs at least. 

How do we make this better? 