### PR TITLE
@s3/store: Allow disabling tagging on expiration extension

### DIFF
--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -71,6 +71,17 @@ Options to pass to the AWS S3 SDK.
 Checkout the [`S3ClientConfig`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html)
 docs for the supported options. You need to at least set the `region`, `bucket` name, and your preferred method of authentication.
 
+
+#### `options.expirationPeriodInMilliseconds`
+
+Enables the expiration extension and sets the expiration period of an upload url in milliseconds.
+Once the expiration period has passed, the upload url will return a 410 Gone status code.
+
+#### `options.useTags`
+
+Some S3 providers don't support tagging objects.
+If you are using certain features like the expiration extension and your provider doesn't support tagging, you can set this option to `false` to disable tagging.
+
 ## Extensions
 
 The tus protocol supports optional [extensions][]. Below is a table of the supported extensions in `@tus/s3-store`.

--- a/packages/s3-store/index.ts
+++ b/packages/s3-store/index.ts
@@ -22,6 +22,7 @@ type Options = {
   // The server calculates the optimal part size, which takes this size into account,
   // but may increase it to not exceed the S3 10K parts limit.
   partSize?: number
+  useTags?: boolean
   expirationPeriodInMilliseconds?: number
   // Options to pass to the AWS S3 SDK.
   s3ClientConfig: S3ClientConfig & {bucket: string}
@@ -71,6 +72,7 @@ export class S3Store extends DataStore {
   private client: S3
   private preferredPartSize: number
   private expirationPeriodInMilliseconds = 0
+  private useTags = true
   public maxMultipartParts = 10_000 as const
   public minPartSize = 5_242_880 as const // 5MiB
   public maxUploadSize = 5_497_558_138_880 as const // 5TiB
@@ -89,7 +91,20 @@ export class S3Store extends DataStore {
     this.bucket = bucket
     this.preferredPartSize = partSize || 8 * 1024 * 1024
     this.expirationPeriodInMilliseconds = options.expirationPeriodInMilliseconds ?? 0
+    this.useTags = options.useTags ?? true
     this.client = new S3(restS3ClientConfig)
+  }
+
+  protected shouldUseExpirationTags() {
+    return this.expirationPeriodInMilliseconds !== 0 && this.useTags
+  }
+
+  protected useCompleteTag(value: 'true' | 'false') {
+    if (!this.shouldUseExpirationTags()) {
+      return undefined
+    }
+
+    return `Tus-Completed=${value}`
   }
 
   /**
@@ -104,7 +119,7 @@ export class S3Store extends DataStore {
       Bucket: this.bucket,
       Key: this.infoKey(upload.id),
       Body: JSON.stringify(upload),
-      Tagging: `Tus-Completed=false`,
+      Tagging: this.useCompleteTag('false'),
       Metadata: {
         'upload-id': uploadId,
         'tus-version': TUS_RESUMABLE,
@@ -114,12 +129,16 @@ export class S3Store extends DataStore {
   }
 
   private async completeMetadata(upload: Upload) {
+    if (!this.shouldUseExpirationTags()) {
+      return
+    }
+
     const {'upload-id': uploadId} = await this.getMetadata(upload.id)
     await this.client.putObject({
       Bucket: this.bucket,
       Key: this.infoKey(upload.id),
       Body: JSON.stringify(upload),
-      Tagging: `Tus-Completed=true`,
+      Tagging: this.useCompleteTag('true'),
       Metadata: {
         'upload-id': uploadId,
         'tus-version': TUS_RESUMABLE,
@@ -197,7 +216,7 @@ export class S3Store extends DataStore {
       Bucket: this.bucket,
       Key: this.partKey(id, true),
       Body: readStream,
-      Tagging: 'Tus-Completed=false',
+      Tagging: this.useCompleteTag('false'),
     })
     log(`[${id}] finished uploading incomplete part`)
     return data.ETag as string


### PR DESCRIPTION
This PR fixes #538 introduces a new option `useTags` which will allow disabling tagging objects for S3 providers who don't support them.

Tags will be now used only if the expiration extension is used.