### PR TITLE
@tus/server: Metadata on namingFunction + propagate error

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -104,7 +104,7 @@ By default, it expects everything in the path after the last `/` to be the uploa
 
 #### `options.namingFunction`
 
-Control how you want to name files (`(req) => string`)
+Control how you want to name files (`(req, metadata) => string`)
 
 In `@tus/server`, the upload ID in the URL is the same as the file name.
 This means using a custom `namingFunction` will return a different `Location` header for uploading

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -54,9 +54,18 @@ export class PostHandler extends BaseHandler {
       throw ERRORS.INVALID_LENGTH
     }
 
+    let metadata
+    if ('upload-metadata' in req.headers) {
+      try {
+        metadata = Metadata.parse(upload_metadata)
+      } catch {
+        throw ERRORS.INVALID_METADATA
+      }
+    }
+
     let id
     try {
-      id = this.options.namingFunction(req)
+      id = this.options.namingFunction(req, metadata)
     } catch (error) {
       log('create: check your `namingFunction`. Error', error)
       throw error
@@ -70,15 +79,6 @@ export class PostHandler extends BaseHandler {
       Number.parseInt(upload_length, 10) > maxFileSize
     ) {
       throw ERRORS.ERR_MAX_SIZE_EXCEEDED
-    }
-
-    let metadata
-    if ('upload-metadata' in req.headers) {
-      try {
-        metadata = Metadata.parse(upload_metadata)
-      } catch {
-        throw ERRORS.INVALID_METADATA
-      }
     }
 
     if (this.options.onIncomingRequest) {

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -59,7 +59,7 @@ export class PostHandler extends BaseHandler {
       id = this.options.namingFunction(req)
     } catch (error) {
       log('create: check your `namingFunction`. Error', error)
-      throw ERRORS.FILE_WRITE_ERROR
+      throw error
     }
 
     const maxFileSize = await this.getConfiguredMaxSize(req, id)

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -57,7 +57,10 @@ export type ServerOptions = {
    * Default uses `crypto.randomBytes(16).toString('hex')`.
    * @param req - The incoming HTTP request.
    */
-  namingFunction?: (req: http.IncomingMessage) => string
+  namingFunction?: (
+    req: http.IncomingMessage,
+    metadata?: Record<string, string | null>
+  ) => string
 
   /**
    * The Lock interface defines methods for implementing a locking mechanism.

--- a/packages/server/test/PostHandler.test.ts
+++ b/packages/server/test/PostHandler.test.ts
@@ -76,11 +76,13 @@ describe('PostHandler', () => {
         const handler = new PostHandler(fake_store, {
           path: '/test',
           locker: new MemoryLocker(),
-          namingFunction: sinon.stub().throws(),
+          namingFunction: () => {
+            throw {status_code: 400}
+          },
         })
 
         req.headers = {'upload-length': '1000'}
-        return assert.rejects(() => handler.send(req, res, context), {status_code: 500})
+        return assert.rejects(() => handler.send(req, res, context), {status_code: 400})
       })
 
       it('should call custom namingFunction', async () => {


### PR DESCRIPTION
This small PR simply allows error propagation in the namingFunction.

Currently, if an error is thrown from the `namingFunction` the error is swallowed and a 500 error code is returned.
This behavior is not ideal, in my use case I rely on the `metadata` in order to create a valid uploadID.

For this reason the `metadata` is validated in the naming function. If some of the fields don't pass the validation instead of returning a 400 status code, the application returns a non-ideal 500