### PR TITLE
@tus/server: add possibility to have an async namingFunction

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -104,7 +104,7 @@ By default, it expects everything in the path after the last `/` to be the uploa
 
 #### `options.namingFunction`
 
-Control how you want to name files (`(req, metadata) => string`)
+Control how you want to name files (`(req, metadata) => string | Promise<string>`)
 
 In `@tus/server`, the upload ID in the URL is the same as the file name.
 This means using a custom `namingFunction` will return a different `Location` header for uploading

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -65,7 +65,7 @@ export class PostHandler extends BaseHandler {
 
     let id
     try {
-      id = this.options.namingFunction(req, metadata)
+      id = await Promise.resolve(this.options.namingFunction(req, metadata))
     } catch (error) {
       log('create: check your `namingFunction`. Error', error)
       throw error

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -65,7 +65,7 @@ export class PostHandler extends BaseHandler {
 
     let id
     try {
-      id = await Promise.resolve(this.options.namingFunction(req, metadata))
+      id = await this.options.namingFunction(req, metadata)
     } catch (error) {
       log('create: check your `namingFunction`. Error', error)
       throw error

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -60,7 +60,7 @@ export type ServerOptions = {
   namingFunction?: (
     req: http.IncomingMessage,
     metadata?: Record<string, string | null>
-  ) => string
+  ) => string | Promise<string>
 
   /**
    * The Lock interface defines methods for implementing a locking mechanism.

--- a/packages/server/test/PostHandler.test.ts
+++ b/packages/server/test/PostHandler.test.ts
@@ -99,6 +99,20 @@ describe('PostHandler', () => {
         assert.equal(namingFunction.calledOnce, true)
       })
 
+      it('should call custom async namingFunction', async () => {
+        const fake_store = sinon.createStubInstance(DataStore)
+        const namingFunction = sinon.stub().resolves('1234')
+        const handler = new PostHandler(fake_store, {
+          path: '/test/',
+          namingFunction,
+          locker: new MemoryLocker(),
+        })
+
+        req.headers = {'upload-length': '1000'}
+        await handler.send(req, res, context)
+        assert.equal(namingFunction.calledOnce, true)
+      })
+
       it('should send error when store rejects', () => {
         const fake_store = sinon.createStubInstance(DataStore)
         fake_store.create.rejects({status_code: 500})


### PR DESCRIPTION
Supporting an async namingFunction enables the check of existing files to ensure there are no collisions.