### PR TITLE
fix: allow lockDrainTimeout to be configurable

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -288,7 +288,7 @@ export class Server extends EventEmitter {
       abortWithDelayController.signal.removeEventListener('abort', onDelayedAbort)
       setTimeout(() => {
         requestAbortController.abort(err)
-      }, 3000)
+      }, this.options.lockDrainTimeout || 3000)
     }
     abortWithDelayController.signal.addEventListener('abort', onDelayedAbort)
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -72,6 +72,11 @@ export type ServerOptions = {
     | ((req: http.IncomingMessage) => Locker | Promise<Locker>)
 
   /**
+   * This timeout controls how long the server will wait a cancelled lock to do its cleanup.
+   */
+  lockDrainTimeout?: number
+
+  /**
    * Disallow termination for finished uploads.
    */
   disableTerminationForFinishedUploads?: boolean


### PR DESCRIPTION

This PR simply allows customizing the `lockDrainTimeout` option.

When a request gets canceled by another lock, this option allow the cancelled request to wait until the `lockDrainTimeout` before starting the shutdown procedure, this is useful when we want to give a bit more time to a request to try and finish gracefully. 

On the cancelling side, the lock will be held for this same period