### PR TITLE
@tus/server: allow metadata changes in onUploadCreate

### DIFF
--- a/.changeset/wild-actors-leave.md
+++ b/.changeset/wild-actors-leave.md
@@ -1,0 +1,5 @@
+---
+'@tus/server': minor
+---
+
+Allow onUploadCreate hook to override metadata

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -140,11 +140,12 @@ finished uploads. (`boolean`)
 #### `options.onUploadCreate`
 
 `onUploadCreate` will be invoked before a new upload is created.
-(`(req, res, upload) => Promise<res>`).
+(`(req, res, upload) => Promise<{ res: http.ServerResponse, metadata?: Record<string, string>}>`).
 
-If the function returns the (modified) response, the upload will be created. You can
-`throw` an Object and the HTTP request will be aborted with the provided `body` and
-`status_code` (or their fallbacks).
+- If the function returns the (modified) response the upload will be created.
+- You can optionally return `metadata` which will override (not merge!) `upload.metadata`.
+- You can `throw` an Object and the HTTP request will be aborted with the provided `body`
+  and `status_code` (or their fallbacks).
 
 This can be used to implement validation of upload metadata or add headers.
 
@@ -445,13 +446,14 @@ const {Server} = require('@tus/server')
 const server = new Server({
   // ..
   async onUploadCreate(req, res, upload) {
-    const {ok, expected, received} = validateMetadata(upload)
+    const {ok, expected, received} = validateMetadata(upload) // your logic
     if (!ok) {
       const body = `Expected "${expected}" in "Upload-Metadata" but received "${received}"`
       throw {status_code: 500, body} // if undefined, falls back to 500 with "Internal server error".
     }
-    // We have to return the (modified) response.
-    return res
+    // You can optionally return metadata to override the upload metadata
+    const extraMeta = getExtraMetadata(req) // your logic
+    return {res, metadata: {...upload.metadata, ...extraMeta}}
   },
 })
 ```

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -451,7 +451,8 @@ const server = new Server({
       const body = `Expected "${expected}" in "Upload-Metadata" but received "${received}"`
       throw {status_code: 500, body} // if undefined, falls back to 500 with "Internal server error".
     }
-    // You can optionally return metadata to override the upload metadata
+    // You can optionally return metadata to override the upload metadata,
+    // such as `{ storagePath: "/upload/123abc..." }`
     const extraMeta = getExtraMetadata(req) // your logic
     return {res, metadata: {...upload.metadata, ...extraMeta}}
   },

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -12,7 +12,7 @@ import {
 } from '@tus/utils'
 import {validateHeader} from '../validators/HeaderValidator'
 
-import type http from 'node:http'
+import http from 'node:http'
 import type {ServerOptions, WithRequired} from '../types'
 
 const log = debug('tus-node-server:handlers:post')
@@ -100,7 +100,16 @@ export class PostHandler extends BaseHandler {
 
     if (this.options.onUploadCreate) {
       try {
-        res = await this.options.onUploadCreate(req, res, upload)
+        const resOrObject = await this.options.onUploadCreate(req, res, upload)
+        // Backwards compatibility, remove in next major
+        if (resOrObject instanceof http.ServerResponse) {
+          res = resOrObject
+        } else {
+          res = resOrObject.res
+          if (resOrObject.metadata) {
+            upload.metadata = resOrObject.metadata
+          }
+        }
       } catch (error) {
         log(`onUploadCreate error: ${error.body}`)
         throw error

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -90,7 +90,10 @@ export type ServerOptions = {
     req: http.IncomingMessage,
     res: http.ServerResponse,
     upload: Upload
-  ) => Promise<http.ServerResponse>
+  ) => Promise<
+    // TODO: change in the next major
+    http.ServerResponse | {res: http.ServerResponse; metadata?: Upload['metadata']}
+  >
 
   /**
    * `onUploadFinish` will be invoked after an upload is completed but before a response is returned to the client.

--- a/packages/server/test/Server.test.ts
+++ b/packages/server/test/Server.test.ts
@@ -440,7 +440,7 @@ describe('Server', () => {
         .set('Upload-Length', '4')
         .expect(201)
         .then((res) => {
-          request(server.listen())
+          request(s)
             .head(removeProtocol(res.headers.location))
             .set('Tus-Resumable', TUS_RESUMABLE)
             .expect(200)

--- a/packages/server/test/Server.test.ts
+++ b/packages/server/test/Server.test.ts
@@ -10,7 +10,7 @@ import request from 'supertest'
 
 import {Server} from '../src'
 import {FileStore} from '@tus/file-store'
-import {TUS_RESUMABLE, EVENTS, DataStore} from '@tus/utils'
+import {TUS_RESUMABLE, EVENTS, DataStore, Metadata} from '@tus/utils'
 import httpMocks from 'node-mocks-http'
 import sinon from 'sinon'
 
@@ -421,6 +421,35 @@ describe('Server', () => {
         .set('Tus-Resumable', TUS_RESUMABLE)
         .set('Upload-Length', '4')
         .expect(500, 'no', done)
+    })
+
+    it('should allow metadata to be changed in onUploadCreate', (done) => {
+      const filename = 'foo.txt'
+      const server = new Server({
+        path: '/test/output',
+        datastore: new FileStore({directory}),
+        async onUploadCreate(_, res, upload) {
+          const metadata = {...upload.metadata, filename}
+          return {res, metadata}
+        },
+      })
+      const s = server.listen()
+      request(s)
+        .post(server.options.path)
+        .set('Tus-Resumable', TUS_RESUMABLE)
+        .set('Upload-Length', '4')
+        .expect(201)
+        .then((res) => {
+          request(server.listen())
+            .head(removeProtocol(res.headers.location))
+            .set('Tus-Resumable', TUS_RESUMABLE)
+            .expect(200)
+            .then((r) => {
+              const metadata = Metadata.parse(r.headers['upload-metadata'])
+              assert.equal(metadata.filename, filename)
+              done()
+            })
+        })
     })
 
     it('should call onUploadFinish and return its error to the client', (done) => {


### PR DESCRIPTION
Closes #594 
Ref: #598 
Ref: #593

The types are atrocious because TS only understands type narrowing with `instanceof` but we can't use that because tests use mocked versions of `http.ServerResponse`.