### PR TITLE
@tus/server: add `lastPath` arg to `getFileIdFromRequest`

### DIFF
--- a/.changeset/smooth-kiwis-grow.md
+++ b/.changeset/smooth-kiwis-grow.md
@@ -1,0 +1,5 @@
+---
+'@tus/server': minor
+---
+
+Add `lastPath` argument to `getFileIdFromRequest` to simplify a common use case.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -106,8 +106,11 @@ Checkout the example how to
 
 #### `options.getFileIdFromRequest`
 
-Control how the Upload-ID is extracted from the request (`(req) => string | void`) By
-default, it expects everything in the path after the last `/` to be the upload id.
+Control how the Upload-ID is extracted from the request
+(`(req, lastPath) => string | void`)
+
+By default, it expects everything in the path after the last `/` to be the upload id.
+`lastPath` is everything after the last `/`.
 
 Checkout the example how to
 [store files in custom nested directories](#example-store-files-in-custom-nested-directories).
@@ -157,7 +160,8 @@ This can be used to implement validation of upload metadata or add headers.
 #### `options.onUploadFinish`
 
 `onUploadFinish` will be invoked after an upload is completed but before a response is
-returned to the client (`(req, res, upload) => Promise<{ res: http.ServerResponse, status_code?: number, headers?: Record<string, string | number>, body?: string }>`).
+returned to the client
+(`(req, res, upload) => Promise<{ res: http.ServerResponse, status_code?: number, headers?: Record<string, string | number>, body?: string }>`).
 
 - You can optionally return `status_code`, `headers` and `body` to modify the response.
   Note that the tus specification does not allow sending response body nor status code
@@ -254,8 +258,9 @@ Called every [`postReceiveInterval`](#optionspostreceiveinterval) milliseconds f
 upload while it‘s being written to the store.
 
 This means you are not guaranteed to get (all) events for an upload. For instance if
-`postReceiveInterval` is set to 1000ms and an PATCH request takes 500ms, no event is emitted.
-If the PATCH request takes 2500ms, you would get the offset at 2000ms, but not at 2500ms.
+`postReceiveInterval` is set to 1000ms and an PATCH request takes 500ms, no event is
+emitted. If the PATCH request takes 2500ms, you would get the offset at 2000ms, but not at
+2500ms.
 
 Use `POST_FINISH` if you need to know when an upload is done.
 
@@ -543,18 +548,13 @@ const server = new Server({
     id = Buffer.from(id, 'utf-8').toString('base64url')
     return `${proto}://${host}${path}/${id}`
   },
-  getFileIdFromRequest(req) {
-    const reExtractFileID = /([^/]+)\/?$/
-    const match = reExtractFileID.exec(req.url as string)
-
-    if (!match || path.includes(match[1])) {
-      return
-    }
-
-    return Buffer.from(match[1], 'base64url').toString('utf-8')
+  getFileIdFromRequest(req, lastPath) {
+    // lastPath is everything after the last `/`
+    // If your custom URL is different, this might be undefined
+    // and you need to extract the ID yourself
+    return Buffer.from(lastPath, 'base64url').toString('utf-8')
   },
 })
-
 ```
 
 ### Example: use with Nginx

--- a/packages/server/src/handlers/BaseHandler.ts
+++ b/packages/server/src/handlers/BaseHandler.ts
@@ -63,10 +63,12 @@ export class BaseHandler extends EventEmitter {
   }
 
   getFileIdFromRequest(req: http.IncomingMessage) {
-    if (this.options.getFileIdFromRequest) {
-      return this.options.getFileIdFromRequest(req)
-    }
     const match = reExtractFileID.exec(req.url as string)
+
+    if (this.options.getFileIdFromRequest) {
+      const lastPath = match ? decodeURIComponent(match[1]) : undefined
+      return this.options.getFileIdFromRequest(req, lastPath)
+    }
 
     if (!match || this.options.path.includes(match[1])) {
       return

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -53,7 +53,7 @@ export type ServerOptions = {
    * Control how the Upload-ID is extracted from the request.
    * @param req - The incoming HTTP request.
    */
-  getFileIdFromRequest?: (req: http.IncomingMessage) => string | void
+  getFileIdFromRequest?: (req: http.IncomingMessage, lastPath?: string) => string | void
 
   /**
    * Control how you want to name files.

--- a/packages/server/test/Server.test.ts
+++ b/packages/server/test/Server.test.ts
@@ -295,15 +295,12 @@ describe('Server', () => {
           id = Buffer.from(id, 'utf-8').toString('base64url')
           return `${proto}://${host}${path}/${id}`
         },
-        getFileIdFromRequest(req) {
-          const reExtractFileID = /([^/]+)\/?$/
-          const match = reExtractFileID.exec(req.url as string)
-
-          if (!match || route.includes(match[1])) {
+        getFileIdFromRequest(req, lastPath) {
+          if (!lastPath) {
             return
           }
 
-          return Buffer.from(match[1], 'base64url').toString('utf-8')
+          return Buffer.from(lastPath, 'base64url').toString('utf-8')
         },
       })
       const length = Buffer.byteLength('test', 'utf8').toString()


### PR DESCRIPTION
As soon as people want nested directories they have to implement `namingFunction`,`generateUrl`, and `getFileIdFromRequest`. 

Almost always, the last part of the path (after last `/`) is the ID. It's therefor a little awkward to let users repeat our internal code in `getFileIdFromRequest` again.

```js
const path = '/files'
const server = new Server({
  path,
  datastore: new FileStore({directory: './test/output'}),
  namingFunction(req) {
    const id = crypto.randomBytes(16).toString('hex')
    const folder = getFolderForUser(req) // your custom logic
    return `users/${folder}/${id}`
  },
  generateUrl(req, {proto, host, path, id}) {
    id = Buffer.from(id, 'utf-8').toString('base64url')
    return `${proto}://${host}${path}/${id}`
  },
  getFileIdFromRequest(req) {
    const reExtractFileID = /([^/]+)\/?$/
    const match = reExtractFileID.exec(req.url as string)

    if (!match || path.includes(match[1])) {
      return
    }

    return Buffer.from(match[1], 'base64url').toString('utf-8')
  },
})

```


Which can be simplified to this for most cases now:

```js
const server = new Server({
  // ...
  getFileIdFromRequest(req, lastPath) {
    return Buffer.from(lastPath, 'base64url').toString('utf-8')
  },
})
```
