### PR TITLE
Improved redis kv stores

### DIFF
--- a/.changeset/breezy-llamas-juggle.md
+++ b/.changeset/breezy-llamas-juggle.md
@@ -1,0 +1,5 @@
+---
+"@tus/utils": minor
+---
+
+Add IoRedisKvStore & use redis.scan instead of discouraged redis.keys

--- a/.changeset/smooth-gifts-beam.md
+++ b/.changeset/smooth-gifts-beam.md
@@ -1,0 +1,5 @@
+---
+"@tus/server": minor
+---
+
+Add ioredis as optional dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@tus/file-store": "^1.5.0",
         "@tus/gcs-store": "^1.4.0",
         "@tus/s3-store": "^1.6.0",
-        "@tus/server": "^1.8.0",
+        "@tus/server": "^1.9.0",
         "tus-js-client": "^2.3.2"
       },
       "devDependencies": {
@@ -1724,6 +1724,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "dev": true
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "dev": true,
@@ -3352,8 +3358,8 @@
     },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3679,6 +3685,15 @@
     "node_modules/demo": {
       "resolved": "demo",
       "link": true
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
@@ -4628,6 +4643,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
+      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+      "dev": true,
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
@@ -5102,10 +5141,22 @@
         "lodash._basetostring": "~4.12.0"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
@@ -6160,6 +6211,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "dev": true,
@@ -6635,6 +6707,12 @@
       "version": "1.0.3",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "dev": true
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -7635,7 +7713,7 @@
     },
     "packages/server": {
       "name": "@tus/server",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@tus/utils": "^0.4.0",
@@ -7671,6 +7749,7 @@
         "@types/debug": "^4.1.12",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.5",
+        "ioredis": "^5.4.1",
         "mocha": "^10.4.0",
         "should": "^13.2.3",
         "ts-node": "^10.9.2"
@@ -7684,7 +7763,7 @@
         "@tus/file-store": "^1.5.0",
         "@tus/gcs-store": "^1.4.0",
         "@tus/s3-store": "^1.6.0",
-        "@tus/server": "^1.8.0"
+        "@tus/server": "^1.9.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,7 +1728,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
       "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
@@ -3690,7 +3690,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4647,7 +4647,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
       "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -5145,7 +5145,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -5156,7 +5156,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
@@ -6215,7 +6215,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6224,7 +6224,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -6712,7 +6712,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -7738,7 +7738,8 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@redis/client": "^1.5.13"
+        "@redis/client": "^1.5.13",
+        "ioredis": "^5.4.1"
       }
     },
     "packages/utils": {

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -146,7 +146,7 @@ to abort incomplete multipart uploads.
 
 Unlike other stores, the expiration extension on the S3 store does not need to call
 [`server.cleanUpExpiredUploads()`][cleanExpiredUploads]. The store creates a
-`Tus-Complete` tag for all objects, including `.part` and `.info` files, to indicate
+`Tus-Completed` tag for all objects, including `.part` and `.info` files, to indicate
 whether an upload is finished. This means you could setup a [lifecyle][] policy to
 automatically clean them up without a CRON job.
 
@@ -156,7 +156,7 @@ automatically clean them up without a CRON job.
     {
       "Filter": {
         "Tag": {
-          "Key": "Tus-Complete",
+          "Key": "Tus-Completed",
           "Value": "false"
         }
       },

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -342,13 +342,28 @@ import S3Store, {type MetadataValue} from '@tus/s3-store'
 import {createClient} from '@redis/client'
 
 const client = await createClient().connect()
-const path = './uploads'
 const prefix = 'foo' // prefix for the key (foo${id})
 
 new S3Store({
   // ...
   cache: new RedisKvStore<MetadataValue>(client, prefix),
 })
+```
+
+#### `IoRedisKvStore`
+
+```ts
+import { IoRedisKvStore } from '@tus/server';
+import S3Store, { type MetadataValue } from '@tus/s3-store';
+import Redis from 'ioredis';
+
+const client = new Redis();
+const prefix = 'foo'; // prefix for the key (foo${id})
+
+new S3Store({
+  // ...
+  cache: new IoRedisKvStore<MetadataValue>(client, prefix),
+});
 ```
 
 ## Examples

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,7 +33,8 @@
     "ts-node": "^10.9.2"
   },
   "optionalDependencies": {
-    "@redis/client": "^1.5.13"
+    "@redis/client": "^1.5.13",
+    "ioredis": "^5.4.1"
   },
   "engines": {
     "node": ">=16"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,12 +8,7 @@
   "bugs": "https://github.com/tus/tus-node-server/issues",
   "repository": "tus/tus-node-server",
   "license": "MIT",
-  "files": [
-    "README.md",
-    "LICENSE",
-    "dist",
-    "src"
-  ],
+  "files": ["README.md", "LICENSE", "dist", "src"],
   "scripts": {
     "build": "tsc --build",
     "test": "mocha --timeout 40000 --exit --extension ts --require ts-node/register"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,6 +17,7 @@
     "@types/debug": "^4.1.12",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.5",
+    "ioredis": "^5.4.1",
     "mocha": "^10.4.0",
     "should": "^13.2.3",
     "ts-node": "^10.9.2"

--- a/packages/utils/src/kvstores/IoRedisKvStore.ts
+++ b/packages/utils/src/kvstores/IoRedisKvStore.ts
@@ -1,5 +1,4 @@
-
-import type {Redis as IoRedis} from "ioredis"
+import type {Redis as IoRedis} from 'ioredis'
 import type {KvStore} from './Types'
 import type {Upload} from '../models'
 
@@ -30,12 +29,18 @@ export class IoRedisKvStore<T = Upload> implements KvStore<T> {
 
   async list(): Promise<Array<string>> {
     const keys = new Set<string>()
-    let cursor = "0"
+    let cursor = '0'
     do {
-      const [next, batch] = await this.redis.scan(cursor, "MATCH", this.prefixed("*"), "COUNT", "20")
+      const [next, batch] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        this.prefixed('*'),
+        'COUNT',
+        '20'
+      )
       cursor = next
       for (const key of batch) keys.add(key)
-    } while (cursor !== "0")
+    } while (cursor !== '0')
     return Array.from(keys)
   }
 
@@ -47,5 +52,3 @@ export class IoRedisKvStore<T = Upload> implements KvStore<T> {
     return buffer ? JSON.parse(buffer) : undefined
   }
 }
-
-

--- a/packages/utils/src/kvstores/RedisKvStore.ts
+++ b/packages/utils/src/kvstores/RedisKvStore.ts
@@ -32,7 +32,7 @@ export class RedisKvStore<T = Upload> implements KvStore<T> {
     const keys = new Set<string>()
     let cursor = 0
     do {
-      const result = await this.redis.scan(cursor, { MATCH: `${this.prefix}*`, COUNT: 20 })
+      const result = await this.redis.scan(cursor, {MATCH: `${this.prefix}*`, COUNT: 20})
       cursor = result.cursor
       for (const key of result.keys) keys.add(key)
     } while (cursor !== 0)

--- a/packages/utils/src/kvstores/index.ts
+++ b/packages/utils/src/kvstores/index.ts
@@ -1,4 +1,5 @@
 export {FileKvStore} from './FileKvStore'
 export {MemoryKvStore} from './MemoryKvStore'
 export {RedisKvStore} from './RedisKvStore'
+export {IoRedisKvStore} from './IoRedisKvStore'
 export {KvStore} from './Types'


### PR DESCRIPTION
#### Use `SCAN` instead of `KEYS` when getting ids from Redis KV store.

From [redis docs](https://redis.io/docs/latest/commands/keys/):

>Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout. Don't use KEYS in your regular application code. If you're looking for a way to find keys in a subset of your keyspace, consider using [SCAN](https://redis.io/docs/latest/commands/scan/) or [sets](https://redis.io/docs/latest/develop/data-types/sets/).

#### Add support for ioredis

Added a new IoRedisKvStore. `SCAN` and raw command method signatures aren't compatible between node-redis and ioredis. Separate class is more maintainable and safer than making the redis client type an union and trying to figure out which client it's using at runtime.