### PR TITLE
@tus/s3-store: Change private modifier into protected

### DIFF
--- a/.changeset/cyan-hornets-repair.md
+++ b/.changeset/cyan-hornets-repair.md
@@ -1,0 +1,5 @@
+---
+"@tus/s3-store": minor
+---
+
+Change private modifier to protected


### PR DESCRIPTION
Changes the `private` modifier in S3 store into `protected` so that they can be extended. I've also exported the `Options` type so that it can be used while extending.