### PR TITLE
fix: handling consistent cancellation across stream and locks

### DIFF
--- a/.changeset/calm-adults-roll.md
+++ b/.changeset/calm-adults-roll.md
@@ -1,0 +1,6 @@
+---
+"@tus/server": patch
+"@tus/utils": patch
+---
+
+Consistent cancellation across streams and locks, fixing lock on file never being unlocked when the request ends prematurely.

--- a/packages/server/test/Locker.test.ts
+++ b/packages/server/test/Locker.test.ts
@@ -6,6 +6,7 @@ describe('MemoryLocker', () => {
   it('will acquire a lock by notifying another to release it', async () => {
     const locker = new MemoryLocker()
     const lockId = 'upload-id-1'
+    const abortController = new AbortController()
 
     const cancel = sinon.spy()
     const cancel2 = sinon.spy()
@@ -13,12 +14,12 @@ describe('MemoryLocker', () => {
     const lock1 = locker.newLock(lockId)
     const lock2 = locker.newLock(lockId)
 
-    await lock1.lock(async () => {
+    await lock1.lock(abortController.signal, async () => {
       await lock1.unlock()
       cancel()
     })
 
-    await lock2.lock(async () => {
+    await lock2.lock(abortController.signal, async () => {
       cancel2()
     })
 
@@ -32,19 +33,21 @@ describe('MemoryLocker', () => {
     const locker = new MemoryLocker({
       acquireLockTimeout: 500,
     })
+    const abortController = new AbortController()
+
     const lockId = 'upload-id-1'
     const lock = locker.newLock(lockId)
 
     const cancel = sinon.spy()
 
-    await lock.lock(async () => {
+    await lock.lock(abortController.signal, async () => {
       cancel()
       // We note that the function has been called, but do not
       // release the lock
     })
 
     try {
-      await lock.lock(async () => {
+      await lock.lock(abortController.signal, async () => {
         throw new Error('panic should not be called')
       })
     } catch (e) {
@@ -57,18 +60,20 @@ describe('MemoryLocker', () => {
   it('request lock and unlock', async () => {
     const locker = new MemoryLocker()
     const lockId = 'upload-id-1'
+    const abortController = new AbortController()
+
     const lock = locker.newLock(lockId)
     const lock2 = locker.newLock(lockId)
 
     const cancel = sinon.spy()
-    await lock.lock(() => {
+    await lock.lock(abortController.signal, () => {
       cancel()
       setTimeout(async () => {
         await lock.unlock()
       }, 50)
     })
 
-    await lock2.lock(() => {
+    await lock2.lock(abortController.signal, () => {
       throw new Error('should not be called')
     })
 
@@ -78,5 +83,39 @@ describe('MemoryLocker', () => {
       cancel.callCount > 0,
       `request released called more times than expected - ${cancel.callCount}`
     )
+  })
+
+  it('will stop trying to acquire the lock if the abort signal is aborted', async () => {
+    const locker = new MemoryLocker()
+    const lockId = 'upload-id-1'
+    const abortController = new AbortController()
+
+    const cancel = sinon.spy()
+    const cancel2 = sinon.spy()
+
+    const lock1 = locker.newLock(lockId)
+    const lock2 = locker.newLock(lockId)
+
+    await lock1.lock(abortController.signal, async () => {
+      // do not unlock when requested
+      cancel()
+    })
+
+    // Abort signal is aborted after lock2 tries to acquire the lock
+    setTimeout(() => {
+      abortController.abort()
+    }, 100)
+
+    try {
+      await lock2.lock(abortController.signal, async () => {
+        cancel2()
+      })
+      assert(false, 'lock2 should not have been acquired')
+    } catch (e) {
+      assert(e === ERRORS.ERR_LOCK_TIMEOUT, `error returned is not correct ${e}`)
+    }
+
+    assert(cancel.callCount > 1, `calls count dont match ${cancel.callCount} !== 1`)
+    assert(cancel2.callCount === 0, `calls count dont match ${cancel.callCount} !== 1`)
   })
 })

--- a/packages/utils/src/models/Locker.ts
+++ b/packages/utils/src/models/Locker.ts
@@ -26,6 +26,6 @@ export interface Locker {
  *
  */
 export interface Lock {
-  lock(cancelReq: RequestRelease): Promise<void>
+  lock(signal: AbortSignal, cancelReq: RequestRelease): Promise<void>
   unlock(): Promise<void>
 }


### PR DESCRIPTION
This PR fixes #697 by always cancelling the context when the `req.on('close')` is emitted.

> The close event on the request (req) object is emitted when the underlying connection is terminated before the request is fully processed. This typically happens when the client abruptly disconnects, closes the browser, or cancels the request (e.g., a page refresh or navigation away).

Handled Cancellation scenarios:

- Client aborts the request (signal is propagated to the proxy stream and lockers)
  - If the locker is trying to acquire a lock, it will stop since there is no more need
  - Lock is acquired, the proxy stream is closed gracefully so that we can finishing uploading the remaining bytes in the buffer before releasing the lock
  
- Client completes the request correctly (without keep alive) the on('close') is still triggered, it will not have any effect but probably good practice to make sure all future resources are clean up.

- Client completes the request correctly (with keep-alive) the on('close') is not triggered, context is still cancelled upon req.on('finish'), it will not have any effect but probably good practice to make sure all future resources are clean up.