### PR TITLE
@tus/s3-store: add `maxMultipartParts` option

### DIFF
--- a/.changeset/tricky-emus-fail.md
+++ b/.changeset/tricky-emus-fail.md
@@ -1,0 +1,5 @@
+---
+"@tus/s3-store": minor
+---
+
+Add `maxMultipartParts` option. This can be used when using S3-compatible storage provider with different part number limitations.

--- a/packages/s3-store/src/index.ts
+++ b/packages/s3-store/src/index.ts
@@ -37,6 +37,10 @@ export type Options = {
    * Can not be lower than 5MiB or more than 5GiB.
    */
   minPartSize?: number
+  /**
+   * The maximum number of parts allowed in a multipart upload. Defaults to 10,000.
+   */
+  maxMultipartParts?: number
   useTags?: boolean
   maxConcurrentPartUploads?: number
   cache?: KvStore<MetadataValue>
@@ -97,13 +101,13 @@ export class S3Store extends DataStore {
   protected expirationPeriodInMilliseconds = 0
   protected useTags = true
   protected partUploadSemaphore: Semaphore
-  public maxMultipartParts = 10_000 as const
+  public maxMultipartParts = 10_000
   public minPartSize = 5_242_880 // 5MiB
   public maxUploadSize = 5_497_558_138_880 as const // 5TiB
 
   constructor(options: Options) {
     super()
-    const {partSize, minPartSize, s3ClientConfig} = options
+    const { maxMultipartParts, partSize, minPartSize, s3ClientConfig } = options
     const {bucket, ...restS3ClientConfig} = s3ClientConfig
     this.extensions = [
       'creation',
@@ -116,6 +120,9 @@ export class S3Store extends DataStore {
     this.preferredPartSize = partSize || 8 * 1024 * 1024
     if (minPartSize) {
       this.minPartSize = minPartSize
+    }
+    if (maxMultipartParts) {
+      this.maxMultipartParts = maxMultipartParts
     }
     this.expirationPeriodInMilliseconds = options.expirationPeriodInMilliseconds ?? 0
     this.useTags = options.useTags ?? true

--- a/packages/s3-store/src/index.ts
+++ b/packages/s3-store/src/index.ts
@@ -107,7 +107,7 @@ export class S3Store extends DataStore {
 
   constructor(options: Options) {
     super()
-    const { maxMultipartParts, partSize, minPartSize, s3ClientConfig } = options
+    const {maxMultipartParts, partSize, minPartSize, s3ClientConfig} = options
     const {bucket, ...restS3ClientConfig} = s3ClientConfig
     this.extensions = [
       'creation',

--- a/packages/s3-store/test/index.ts
+++ b/packages/s3-store/test/index.ts
@@ -278,14 +278,14 @@ describe('S3DataStore', () => {
     }
   })
 
-  it.only('should use default maxMultipartParts when not specified', function () {
+  it('should use default maxMultipartParts when not specified', function () {
     const store = new S3Store({
       s3ClientConfig,
     })
     assert.equal(store.maxMultipartParts, 10000)
   })
 
-  it.only('should use custom maxMultipartParts when specified', function () {
+  it('should use custom maxMultipartParts when specified', function () {
     const customMaxParts = 5000
     const store = new S3Store({
       s3ClientConfig,

--- a/packages/s3-store/test/index.ts
+++ b/packages/s3-store/test/index.ts
@@ -278,6 +278,22 @@ describe('S3DataStore', () => {
     }
   })
 
+  it.only('should use default maxMultipartParts when not specified', function () {
+    const store = new S3Store({
+      s3ClientConfig,
+    })
+    assert.equal(store.maxMultipartParts, 10000)
+  })
+
+  it.only('should use custom maxMultipartParts when specified', function () {
+    const customMaxParts = 5000
+    const store = new S3Store({
+      s3ClientConfig,
+      maxMultipartParts: customMaxParts,
+    })
+    assert.equal(store.maxMultipartParts, customMaxParts)
+  })
+
   shared.shouldHaveStoreMethods()
   shared.shouldCreateUploads()
   shared.shouldRemoveUploads() // Termination extension


### PR DESCRIPTION
This PR closes #711.

I added additional option `maxMultipartParts` which allows user to define non-standard S3 server limitations.

Also some tests for completeness. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configurable option for multipart uploads, allowing users to set a custom maximum parts limit (defaulting to 10,000) for improved flexibility with S3-compatible storage providers.
  
- **Tests**
  - Expanded the test suite to verify the default and custom behaviors of the new multipart upload configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->