### PR TITLE
@tus/s3-store: add missing docs for `maxMultipartParts`

### DIFF
--- a/.changeset/thin-keys-whisper.md
+++ b/.changeset/thin-keys-whisper.md
@@ -2,4 +2,4 @@
 "@tus/s3-store": patch
 ---
 
-Update documentation
+Add missing documentation for `maxMultipartParts` option added in #712

--- a/.changeset/thin-keys-whisper.md
+++ b/.changeset/thin-keys-whisper.md
@@ -1,0 +1,5 @@
+---
+"@tus/s3-store": patch
+---
+
+Update documentation

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -81,7 +81,7 @@ may increase it to not exceed the `options.maxMultipartParts` parts limit.
 The maximum number of parts allowed in a multipart upload. Defaults to 10,000.
 Some S3 providers have non-standard restrictions on the number of parts in a multipart
 upload. For example, AWS S3 has a limit of 10,000 parts, but some S3 compatible providers
-have a limit of 1000 parts.
+have a limit of 1,000 parts.
 
 #### `options.s3ClientConfig`
 

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -74,7 +74,14 @@ by setting `partSize` and `minPartSize` to the same value.
 Can not be lower than 5MiB or more than 5GiB.
 
 The server calculates the optimal part size, which takes this size into account, but
-may increase it to not exceed the S3 10K parts limit.
+may increase it to not exceed the `options.maxMultipartParts` parts limit.
+
+#### `options.maxMultipartParts`
+
+The maximum number of parts allowed in a multipart upload. Defaults to 10,000.
+Some S3 providers have non-standard restrictions on the number of parts in a multipart
+upload. For example, AWS S3 has a limit of 10,000 parts, but some S3 compatible providers
+have a limit of 1000 parts.
 
 #### `options.s3ClientConfig`
 
@@ -222,6 +229,17 @@ This can be achieved by setting `partSize` and `minPartSize` to the same value.
 const s3Store = new S3Store({
   partSize: 8 * 1024 * 1024,
   minPartSize: 8 * 1024 * 1024,
+  // ...
+})
+```
+
+### Example: use with Scaleway Object Storage
+
+`@tus/s3-store` can be used with Scaleway Object Storage but with some additional configuration. Scaleway Object Storage has a limit of 1000 parts in a multipart upload.
+
+```ts
+const s3Store = new S3Store({
+  maxMultipartParts: 1000,
   // ...
 })
 ```

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -14,6 +14,7 @@
 - [Examples](#examples)
   - [Example: using `credentials` to fetch credentials inside a AWS container](#example-using-credentials-to-fetch-credentials-inside-a-aws-container)
   - [Example: use with Cloudflare R2](#example-use-with-cloudflare-r2)
+  - [Example: use with Scaleway Object Storage](#example-use-with-scaleway-object-storage)
 - [Types](#types)
 - [Compatibility](#compatibility)
 - [Contribute](#contribute)

--- a/packages/s3-store/README.md
+++ b/packages/s3-store/README.md
@@ -236,7 +236,7 @@ const s3Store = new S3Store({
 
 ### Example: use with Scaleway Object Storage
 
-`@tus/s3-store` can be used with Scaleway Object Storage but with some additional configuration. Scaleway Object Storage has a limit of 1000 parts in a multipart upload.
+`@tus/s3-store` can be used with Scaleway Object Storage but with some additional configuration. Scaleway Object Storage has a limit of 1,000 parts in a multipart upload.
 
 ```ts
 const s3Store = new S3Store({


### PR DESCRIPTION
I didn't update documentation in #712. 