### PR TITLE
@tus/s3-store: fix unhandled promise rejection

### DIFF
--- a/packages/s3-store/package.json
+++ b/packages/s3-store/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc --build",
+    "pretest": "tsc --build",
     "test": "mocha --timeout 40000 --exit --extension ts --require ts-node/register"
   },
   "dependencies": {

--- a/packages/s3-store/test/index.ts
+++ b/packages/s3-store/test/index.ts
@@ -278,20 +278,52 @@ describe('S3DataStore', () => {
     }
   })
 
-  it('should use default maxMultipartParts when not specified', function () {
+  it('should use default maxMultipartParts when not specified', () => {
     const store = new S3Store({
       s3ClientConfig,
     })
     assert.equal(store.maxMultipartParts, 10000)
   })
 
-  it('should use custom maxMultipartParts when specified', function () {
+  it('should use custom maxMultipartParts when specified', () => {
     const customMaxParts = 5000
     const store = new S3Store({
       s3ClientConfig,
       maxMultipartParts: customMaxParts,
     })
     assert.equal(store.maxMultipartParts, customMaxParts)
+  })
+
+  it('should handle multiple concurrent part uploads with some failures', async () => {
+    const store = new S3Store({
+      partSize: 5 * 1024 * 1024,
+      maxConcurrentPartUploads: 3, // Allow 3 concurrent uploads
+      s3ClientConfig,
+    })
+
+    const size = 15 * 1024 * 1024 // 15MB will be split into 3 parts
+    const upload = new Upload({
+      id: shared.testId('concurrent-failures'),
+      size,
+      offset: 0,
+    })
+
+    // @ts-expect-error private method
+    const uploadPartStub = sinon.stub(store, 'uploadPart')
+
+    // Make the second part upload fail
+    uploadPartStub.onCall(0).resolves('etag1')
+    uploadPartStub.onCall(1).rejects(new Error('Part 2 upload failed'))
+    uploadPartStub.onCall(2).resolves('etag3')
+
+    await store.create(upload)
+
+    try {
+      await store.write(Readable.from(Buffer.alloc(size)), upload.id, upload.offset)
+      assert.fail('Expected write to fail but it succeeded')
+    } catch (error) {
+      assert.equal(uploadPartStub.callCount, 2, '2 parts should have been attempted')
+    }
   })
 
   shared.shouldHaveStoreMethods()


### PR DESCRIPTION
Ref: #722 

May need another breaking change to close the issue but this is already an improvement for the 1.x line. 

Without these changes, the new test would fail as 3 `uploadParts` attempts were made instead of 2 (stopping at failure)

- [ ] Look into promise rejection warning

```
  S3DataStore
    ✔ should handle multiple concurrent part uploads with some failures (1069ms)
(node:14818) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 12)
```