### PR TITLE
@tus/server: make upload-offset a string

### DIFF
--- a/.changeset/happy-countries-ring.md
+++ b/.changeset/happy-countries-ring.md
@@ -1,0 +1,5 @@
+---
+"@tus/server": minor
+---
+
+fix bug: upload-offset header should be string

--- a/.changeset/happy-countries-ring.md
+++ b/.changeset/happy-countries-ring.md
@@ -1,5 +1,5 @@
 ---
-"@tus/server": minor
+"@tus/server": patch
 ---
 
-fix bug: upload-offset header should be string
+Correctly return upload-offset header as a string instead of number

--- a/packages/server/src/handlers/PatchHandler.ts
+++ b/packages/server/src/handlers/PatchHandler.ts
@@ -113,7 +113,7 @@ export class PatchHandler extends BaseHandler {
         status: 204,
         headers: {
           ...Object.fromEntries(headers.entries()),
-          'Upload-Offset': newOffset,
+          'Upload-Offset': newOffset.toString(),
         } as Record<string, string | number>,
         body: '',
       }


### PR DESCRIPTION
Resolves https://github.com/tus/tus-node-server/issues/751 by simply converting the type of "Upload-Offset" header value from number to string.