### PR TITLE
@tus/server: handle request cancellation gracefully

### DIFF
--- a/.changeset/modern-birds-appear.md
+++ b/.changeset/modern-birds-appear.md
@@ -1,0 +1,5 @@
+---
+"@tus/server": patch
+---
+
+Handle request cancellation gracefully on Node.js runtime

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -139,7 +139,7 @@ export class Server extends EventEmitter {
     // This is important to avoid memory leaks and ensure that the server can
     // handle subsequent requests without issues.
     if ('node' in req && req.node) {
-      const nodeReq = (req.node as { req: http.IncomingMessage }).req
+      const nodeReq = (req.node as {req: http.IncomingMessage}).req
       nodeReq.once('error', () => {
         context.abort()
       })

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -228,7 +228,8 @@ export class Server extends EventEmitter {
       if (context.signal.aborted) {
         // If the request was aborted, we should not send any response body.
         // The server should just close the connection.
-        return this.handleAbortedRequest(context, resp)
+        resp.headers.set('Connection', 'close')
+        return resp
       }
 
       return resp
@@ -272,7 +273,7 @@ export class Server extends EventEmitter {
     return new Response(body, {status, headers})
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  // biome-ignore lint/suspicious/noExplicitAny: it's fine
   listen(...args: any[]): http.Server {
     return http.createServer(this.handle.bind(this)).listen(...args)
   }
@@ -283,18 +284,6 @@ export class Server extends EventEmitter {
     }
 
     return this.datastore.deleteExpired()
-  }
-
-  protected handleAbortedRequest(context: CancellationContext, resp: Response) {
-    const isAborted = context.signal.aborted
-    if (isAborted) {
-      // If the request was aborted, we should not send any response body.
-      // The server should just close the connection.
-      resp.headers.set('Connection', 'close')
-      return resp
-    }
-
-    return resp
   }
 
   protected createContext() {


### PR DESCRIPTION
This PR fixes 2 regressions:

- Handle gracefully the request cancellation by aborting the context, which will allow the locks to be released immediately and available to be acquired by subsequent requests. Currently, this has been broken since the context was never cancelled when the request was aborted

- Force closing the connection when the request was aborted, to prevent the client from needing to send the whole body before realising that the upload was cancelled (potentially from another request acquiring the lock)

CC: @Murderlon 
