### PR TITLE
@tus/azure-store: fix metadata parsing bug

### DIFF
--- a/.changeset/small-pillows-hug.md
+++ b/.changeset/small-pillows-hug.md
@@ -1,0 +1,5 @@
+---
+"@tus/azure-store": patch
+---
+
+Fix metadata parsing bug

--- a/packages/azure-store/src/index.ts
+++ b/packages/azure-store/src/index.ts
@@ -117,7 +117,7 @@ export class AzureStore extends DataStore {
     const upload = JSON.parse(propertyData.metadata.upload) as Upload
     // Metadata is base64 encoded to avoid errors for non-ASCII characters
     // so we need to decode it separately
-    upload.metadata = Metadata.parse(JSON.stringify(upload.metadata ?? {}))
+    upload.metadata = upload.metadata ? Metadata.parse(upload.metadata) : {}
 
     await this.cache.set(appendBlobClient.url, upload)
 

--- a/packages/azure-store/src/index.ts
+++ b/packages/azure-store/src/index.ts
@@ -117,7 +117,15 @@ export class AzureStore extends DataStore {
     const upload = JSON.parse(propertyData.metadata.upload) as Upload
     // Metadata is base64 encoded to avoid errors for non-ASCII characters
     // so we need to decode it separately
-    upload.metadata = upload.metadata ? Metadata.parse(upload.metadata) : {}
+    let metadataStr
+    if (typeof upload.metadata === 'string') {
+      metadataStr = upload.metadata
+    } else if (upload.metadata && typeof upload.metadata === 'object') {
+      metadataStr = JSON.stringify(upload.metadata??{})
+    } else {
+      metadataStr = '{}'
+    }
+    upload.metadata = Metadata.parse(metadataStr)
 
     await this.cache.set(appendBlobClient.url, upload)
 

--- a/packages/azure-store/src/index.ts
+++ b/packages/azure-store/src/index.ts
@@ -121,7 +121,7 @@ export class AzureStore extends DataStore {
     if (typeof upload.metadata === 'string') {
       metadataStr = upload.metadata
     } else if (upload.metadata && typeof upload.metadata === 'object') {
-      metadataStr = JSON.stringify(upload.metadata??{})
+      metadataStr = JSON.stringify(upload.metadata ?? {})
     } else {
       metadataStr = '{}'
     }


### PR DESCRIPTION
Removes serialization that wraps the metadata (that's already a string) in quotes.
These quote caused `Metadata.parse` to fail with the following error: "Metadata string is not valid"

Closes #791 