### PR TITLE
@tus/s3-store: gracefully handle zero byte uploads

### DIFF
--- a/.changeset/public-beds-sing.md
+++ b/.changeset/public-beds-sing.md
@@ -1,0 +1,5 @@
+---
+"@tus/s3-store": patch
+---
+
+Handle zero byte uploads gracefully

--- a/packages/s3-store/src/index.ts
+++ b/packages/s3-store/src/index.ts
@@ -1,7 +1,7 @@
 import os from 'node:os'
 import fs, {promises as fsProm} from 'node:fs'
 import stream, {promises as streamProm} from 'node:stream'
-import type {Readable} from 'node:stream'
+import {Readable} from 'node:stream'
 
 import type AWS from '@aws-sdk/client-s3'
 import {NoSuchKey, NotFound, S3, type S3ClientConfig} from '@aws-sdk/client-s3'
@@ -231,7 +231,7 @@ export class S3Store extends DataStore {
 
   protected async uploadPart(
     metadata: MetadataValue,
-    readStream: fs.ReadStream | Readable,
+    readStream: fs.ReadStream | Readable | Buffer,
     partNumber: number
   ): Promise<string> {
     const data = await this.client.uploadPart({
@@ -465,15 +465,9 @@ export class S3Store extends DataStore {
     // Handle zero-byte uploads - S3 requires at least one part to complete a multipart upload
     // S3 allows the last part to be 0 bytes, so we upload a single empty part
     if (parts.length === 0) {
-      const uploadResult = await this.client.uploadPart({
-        Bucket: this.bucket,
-        Key: metadata.file.id,
-        UploadId: metadata['upload-id'],
-        PartNumber: 1,
-        Body: Buffer.alloc(0),
-      })
+      const eTag = await this.uploadPart(metadata, Buffer.alloc(0), 1)
       parts.push({
-        ETag: uploadResult.ETag,
+        ETag: eTag,
         PartNumber: 1,
       })
     }

--- a/packages/s3-store/src/index.ts
+++ b/packages/s3-store/src/index.ts
@@ -445,7 +445,6 @@ export class S3Store extends DataStore {
           log(`[${metadata.file.id}] failed to remove chunk ${pendingChunkFilepath}`)
         }
       }
-
       promises.push(Promise.reject(error))
     } finally {
       // Wait for all promises. We don't want to return
@@ -463,6 +462,22 @@ export class S3Store extends DataStore {
    * This is where S3 concatenates all the uploaded parts.
    */
   protected async finishMultipartUpload(metadata: MetadataValue, parts: Array<AWS.Part>) {
+    // Handle zero-byte uploads - S3 requires at least one part to complete a multipart upload
+    // S3 allows the last part to be 0 bytes, so we upload a single empty part
+    if (parts.length === 0) {
+      const uploadResult = await this.client.uploadPart({
+        Bucket: this.bucket,
+        Key: metadata.file.id,
+        UploadId: metadata['upload-id'],
+        PartNumber: 1,
+        Body: Buffer.alloc(0),
+      })
+      parts.push({
+        ETag: uploadResult.ETag,
+        PartNumber: 1,
+      })
+    }
+
     const response = await this.client.completeMultipartUpload({
       Bucket: this.bucket,
       Key: metadata.file.id,

--- a/packages/s3-store/src/test/index.ts
+++ b/packages/s3-store/src/test/index.ts
@@ -1,12 +1,13 @@
 import path from 'node:path'
 import assert from 'node:assert/strict'
 import {Readable} from 'node:stream'
+import stream from 'node:stream/promises'
 
 import sinon from 'sinon'
 
 import {S3Store} from '@tus/s3-store'
 import * as shared from '../../../utils/dist/test/stores.js'
-import {Upload} from '@tus/utils'
+import {StreamLimiter, Upload} from '@tus/utils'
 
 const fixturesPath = path.resolve('../', '../', 'test', 'fixtures')
 const storePath = path.resolve('../', '../', 'test', 'output', 's3-store')
@@ -18,6 +19,7 @@ const s3ClientConfig = {
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY as string,
   },
   region: process.env.AWS_REGION,
+  endpoint: process.env.AWS_ENDPOINT,
 }
 
 describe('S3DataStore', () => {
@@ -257,6 +259,48 @@ describe('S3DataStore', () => {
       Readable.from(Buffer.alloc(size)),
       upload.id,
       upload.offset
+    )
+    assert.equal(offset, size, 'Write should return 0 offset')
+
+    // Check .info file via getUpload
+    const finalUpload = await store.getUpload(upload.id)
+    assert.equal(finalUpload.offset, size, '.info file should show 0 offset')
+
+    // @ts-expect-error private
+    const s3Client = store.client
+    try {
+      const headResult = await s3Client.getObject({
+        Bucket: s3ClientConfig.bucket,
+        Key: upload.id,
+      })
+
+      assert.equal(headResult.ContentLength, size, 'File should exist in S3 with 0 bytes')
+    } catch (error) {
+      assert.fail(`Zero byte file was not uploaded to S3: ${error.message}`)
+    }
+  })
+
+  it('should upload an empty part when completing zero byte multipart upload', async function () {
+    const store = this.datastore as S3Store
+    const size = 0
+    const upload = new Upload({
+      id: shared.testId('zero-byte-multipart'),
+      size,
+      offset: 0,
+      metadata: {
+        contentType: 'application/octet-stream',
+        cacheControl: 'max-age=3600',
+      },
+    })
+
+    await store.create(upload)
+
+    const offset = await stream.pipeline(
+      Readable.from(Buffer.alloc(size)),
+      new StreamLimiter(999),
+      async (stream) => {
+        return store.write(stream as StreamLimiter, upload.id, upload.offset)
+      }
     )
     assert.equal(offset, size, 'Write should return 0 offset')
 

--- a/packages/s3-store/src/test/index.ts
+++ b/packages/s3-store/src/test/index.ts
@@ -255,46 +255,6 @@ describe('S3DataStore', () => {
 
     await store.create(upload)
 
-    const offset = await store.write(
-      Readable.from(Buffer.alloc(size)),
-      upload.id,
-      upload.offset
-    )
-    assert.equal(offset, size, 'Write should return 0 offset')
-
-    // Check .info file via getUpload
-    const finalUpload = await store.getUpload(upload.id)
-    assert.equal(finalUpload.offset, size, '.info file should show 0 offset')
-
-    // @ts-expect-error private
-    const s3Client = store.client
-    try {
-      const headResult = await s3Client.getObject({
-        Bucket: s3ClientConfig.bucket,
-        Key: upload.id,
-      })
-
-      assert.equal(headResult.ContentLength, size, 'File should exist in S3 with 0 bytes')
-    } catch (error) {
-      assert.fail(`Zero byte file was not uploaded to S3: ${error.message}`)
-    }
-  })
-
-  it('should upload an empty part when completing zero byte multipart upload', async function () {
-    const store = this.datastore as S3Store
-    const size = 0
-    const upload = new Upload({
-      id: shared.testId('zero-byte-multipart'),
-      size,
-      offset: 0,
-      metadata: {
-        contentType: 'application/octet-stream',
-        cacheControl: 'max-age=3600',
-      },
-    })
-
-    await store.create(upload)
-
     const offset = await stream.pipeline(
       Readable.from(Buffer.alloc(size)),
       new StreamLimiter(999),


### PR DESCRIPTION
This PR resolves an issue with zero byte uploads on S3 or Minio.

## Error message

- S3: `MalformedXML: The XML you provided was not well-formed or did not validate against our published schema`
- Minio: `InvalidRequest: You must specify at least one part`

## Reproduction

Any upload with zero bytes will reproduce this issue. This is a simple repro using `tus-js-client`

```JavaScript
import * as tus from 'tus-js-client'
const upload = new tus.Upload(Readable.from(Buffer.alloc(0)), {
  endpoint,
  chunkSize: 1024,
  uploadSize: 0,
  retryDelays: [],
  uploadDataDuringCreation: true,
  metadata: {
    bucketName: 'my-bucket',
    objectName: 'some/object/path.ext',
  },
  onError: (error) => {
    console.error("onError", error)
  },
  onSuccess: () => {
    console.log(`onSuccess`)
  },
})

upload.start()
```

## Additional context

Including the `StreamLimiter` transform as is done [here in BaseHandler](https://github.com/tus/tus-node-server/blob/8906f1454f171a4b964bcf7a4d6fa41a0636f2b9/packages/server/src/handlers/BaseHandler.ts#L189) causes zero byte chunks to not be emitted. This means that `chunkFinished` is never called and therefore no part is ever created. This results in the error as described above because you cannot complete a multipart upload that has no parts.

The test suite already has a test for zero byte uploads, but it doesn't use `StreamLimiter` so it succeeds. I've added a mostly identical test that includes `StreamLimiter` which consistently reproduces the issue.

As a fix I simply check if there are zero parts and add an empty part before trying to finalize the upload.

This PR also adds the AWS_ENDPOINT env to tests to allow testing locally against Minio