### PR TITLE
Support dynamic allowed origins

### DIFF
--- a/.changeset/fuzzy-cats-smile.md
+++ b/.changeset/fuzzy-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"@tus/server": patch
+---
+
+Allow `allowedOrigins` to be a function for dynamic origin validation.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -80,7 +80,8 @@ Trusted origins (`string[]` | `(origin: string) => boolean`).
 
 Sends the client's origin back in `Access-Control-Allow-Origin` if it matches. A function
 can be used to evaluate origins dynamically; when it returns `false`, the
-`Access-Control-Allow-Origin` header is omitted.
+`Access-Control-Allow-Origin` header is omitted. When this option is undefined, the header
+defaults to `*`; an empty array omits the header.
 
 #### `options.postReceiveInterval`
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -76,9 +76,11 @@ Sets `Access-Control-Allow-Credentials` (`boolean`, default: `false`).
 
 #### `options.allowedOrigins`
 
-Trusted origins (`string[]`).
+Trusted origins (`string[]` | `(origin: string) => boolean`).
 
-Sends the client's origin back in `Access-Control-Allow-Origin` if it matches.
+Sends the client's origin back in `Access-Control-Allow-Origin` if it matches. A function
+can be used to evaluate origins dynamically; when it returns `false`, the
+`Access-Control-Allow-Origin` header is omitted.
 
 #### `options.postReceiveInterval`
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -210,10 +210,10 @@ export class Server extends EventEmitter {
     }
 
     // Enable CORS
-    headers.set(
-      'Access-Control-Allow-Origin',
-      this.getCorsOrigin(req.headers.get('origin'))
-    )
+    const corsOrigin = this.getCorsOrigin(req.headers.get('origin'))
+    if (corsOrigin) {
+      headers.set('Access-Control-Allow-Origin', corsOrigin)
+    }
     headers.set(
       'Access-Control-Expose-Headers',
       [...HEADERS, this.options.exposedHeaders ?? []].join(', ')
@@ -241,17 +241,22 @@ export class Server extends EventEmitter {
     return this.write(context, headers, 404, 'Not found\n')
   }
 
-  private getCorsOrigin(origin?: string | null): string {
+  private getCorsOrigin(origin?: string | null): string | null {
+    const {allowedOrigins} = this.options
+
+    if (typeof allowedOrigins === 'function') {
+      return origin && allowedOrigins(origin) ? origin : null
+    }
+
     const isOriginAllowed =
-      this.options.allowedOrigins?.some((allowedOrigin) => allowedOrigin === origin) ??
-      true
+      allowedOrigins?.some((allowedOrigin) => allowedOrigin === origin) ?? true
 
     if (origin && isOriginAllowed) {
       return origin
     }
 
-    if (this.options.allowedOrigins && this.options.allowedOrigins.length > 0) {
-      return this.options.allowedOrigins[0]
+    if (allowedOrigins && allowedOrigins.length > 0) {
+      return allowedOrigins[0]
     }
 
     return '*'

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -248,18 +248,18 @@ export class Server extends EventEmitter {
       return origin && allowedOrigins(origin) ? origin : null
     }
 
-    const isOriginAllowed =
-      allowedOrigins?.some((allowedOrigin) => allowedOrigin === origin) ?? true
-
-    if (origin && isOriginAllowed) {
-      return origin
+    if (!allowedOrigins) {
+      return '*'
     }
 
-    if (allowedOrigins && allowedOrigins.length > 0) {
-      return allowedOrigins[0]
+    if (!origin) {
+      return allowedOrigins[0] ?? null
     }
 
-    return '*'
+    const isOriginAllowed = allowedOrigins.some(
+      (allowedOrigin) => allowedOrigin === origin
+    )
+    return isOriginAllowed ? origin : (allowedOrigins[0] ?? null)
   }
 
   async write(context: CancellationContext, headers: Headers, status: number, body = '') {

--- a/packages/server/src/test/Server.test.ts
+++ b/packages/server/src/test/Server.test.ts
@@ -341,6 +341,34 @@ describe('Server', () => {
         .catch(done)
     })
 
+    it('should support a function for dynamic allowedOrigins', async () => {
+      const origin = 'https://tenant.example.com'
+      const allowedOrigins = new Set<string>()
+      const dynamicServer = new Server({
+        path: '/files',
+        datastore: new DataStore(),
+        allowedOrigins: (requestOrigin) => allowedOrigins.has(requestOrigin),
+      })
+
+      const deniedResponse = await dynamicServer.handleWeb(
+        new Request('http://localhost/files', {
+          method: 'OPTIONS',
+          headers: {Origin: origin},
+        })
+      )
+      assert.equal(deniedResponse.headers.get('Access-Control-Allow-Origin'), null)
+
+      allowedOrigins.add(origin)
+
+      const allowedResponse = await dynamicServer.handleWeb(
+        new Request('http://localhost/files', {
+          method: 'OPTIONS',
+          headers: {Origin: origin},
+        })
+      )
+      assert.equal(allowedResponse.headers.get('Access-Control-Allow-Origin'), origin)
+    })
+
     it('should not invoke handlers if onIncomingRequest throws', (done) => {
       const server = new Server({
         path: '/test/output',

--- a/packages/server/src/test/Server.test.ts
+++ b/packages/server/src/test/Server.test.ts
@@ -274,17 +274,22 @@ describe('Server', () => {
       done()
     })
 
-    it('should allow overriding the HTTP origin', (done) => {
+    it('should return a wildcard origin if allowedOrigins is undefined', async () => {
       const origin = 'vimeo.com'
-      request(listener)
-        .options('/')
-        .set('Origin', origin)
-        .expect(204)
-        .then((res) => {
-          assert.equal(res.headers['access-control-allow-origin'], origin)
-          done()
+      const defaultServer = new Server({
+        path: '/files',
+        datastore: new DataStore(),
+        allowedCredentials: true,
+      })
+      const response = await defaultServer.handleWeb(
+        new Request('http://localhost/files', {
+          method: 'OPTIONS',
+          headers: {Origin: origin},
         })
-        .catch(done)
+      )
+
+      assert.equal(response.headers.get('Access-Control-Allow-Origin'), '*')
+      assert.equal(response.headers.get('Access-Control-Allow-Credentials'), 'true')
     })
 
     it('should allow overriding the HTTP origin only if match allowedOrigins', (done) => {
@@ -336,6 +341,19 @@ describe('Server', () => {
         .expect(204)
         .then((res) => {
           assert.equal(res.headers['access-control-allow-origin'], 'google.com')
+          done()
+        })
+        .catch(done)
+    })
+
+    it('should omit Access-Control-Allow-Origin if allowedOrigins is empty', (done) => {
+      server.options.allowedOrigins = []
+      request(listener)
+        .options('/')
+        .set('Origin', 'vimeo.com')
+        .expect(204)
+        .then((res) => {
+          assert.equal(res.headers['access-control-allow-origin'], undefined)
           done()
         })
         .catch(done)

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -42,9 +42,10 @@ export type ServerOptions = {
   allowedCredentials?: boolean
 
   /**
-   * Add trusted origins to `Access-Control-Allow-Origin`.
+   * Add trusted origins to `Access-Control-Allow-Origin`, or provide a function
+   * to determine whether an origin is trusted.
    */
-  allowedOrigins?: string[]
+  allowedOrigins?: string[] | ((origin: string) => boolean)
 
   /**
    * Interval in milliseconds for sending progress of an upload over `EVENTS.POST_RECEIVE`


### PR DESCRIPTION
## Summary

- allow `ServerOptions.allowedOrigins` to accept an origin predicate
- evaluate the predicate for each request so callers can update their allowlist at runtime
- omit `Access-Control-Allow-Origin` when a predicate rejects an origin or an array is empty
- use the wildcard default instead of reflecting arbitrary origins when no allowlist is configured
- document the new API and add a patch changeset

## Why

Multi-tenant services can gain or remove trusted frontend origins at runtime. A static
array requires rebuilding the `Server`, which can also replace its default in-memory
locker and disrupt in-flight upload concurrency protection.

## Root cause

`allowedOrigins` was typed as `string[]`, and CORS handling called `.some()` directly on
that static array. There was no supported request-time extension point for dynamic
validation. The fallback also reflected arbitrary origins when no allowlist was configured
and returned `*` for an empty configured array.

## User impact

Callers can now back `allowedOrigins` with a database cache, feature flag, or another
dynamic source without reconstructing the server. Existing non-empty array matching and
fallback behavior is unchanged. An empty array now omits `Access-Control-Allow-Origin`,
while an undefined option returns `*`, preserving browser protections for credentialed
requests.

## Validation

- `npm test -w @tus/server` (148 passing, 2 pending)
- `npm run format:check`
- `npm run build`
- focused Biome lint (passes with one pre-existing unused-import warning)

Closes #848

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tus/tus-node-server/pull/849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->