### PR TITLE
@tus/azure-store: fix persisted metadata decoding

### DIFF
--- a/.changeset/fix-azure-metadata-download.md
+++ b/.changeset/fix-azure-metadata-download.md
@@ -1,0 +1,5 @@
+---
+'@tus/azure-store': patch
+---
+
+Fix downloads failing when upload metadata is loaded from Azure Blob Storage.

--- a/packages/azure-store/src/index.ts
+++ b/packages/azure-store/src/index.ts
@@ -33,6 +33,13 @@ type Options =
       containerName: string
     }
 
+type StoredUpload = Pick<
+  Upload,
+  'id' | 'size' | 'offset' | 'storage' | 'creation_date'
+> & {
+  metadata?: string | Upload['metadata']
+}
+
 const log = debug('tus-node-server:stores:azurestore')
 
 /**
@@ -124,10 +131,17 @@ export class AzureStore extends DataStore {
     if (!propertyData.metadata) {
       throw ERRORS.FILE_NOT_FOUND
     }
-    const upload = JSON.parse(propertyData.metadata.upload) as Upload
+    const storedUpload = JSON.parse(propertyData.metadata.upload) as StoredUpload
+    let metadata = storedUpload.metadata
     // Metadata is base64 encoded to avoid errors for non-ASCII characters
     // so we need to decode it separately
-    upload.metadata = Metadata.parse(JSON.stringify(upload.metadata ?? {}))
+    if (typeof metadata === 'string') {
+      metadata = metadata ? Metadata.parse(metadata) : {}
+    }
+    const upload = new Upload({
+      ...storedUpload,
+      metadata: metadata ?? {},
+    })
 
     await this.cache.set(appendBlobClient.url, upload)
 

--- a/packages/azure-store/src/index.ts
+++ b/packages/azure-store/src/index.ts
@@ -33,11 +33,8 @@ type Options =
       containerName: string
     }
 
-type StoredUpload = Pick<
-  Upload,
-  'id' | 'size' | 'offset' | 'storage' | 'creation_date'
-> & {
-  metadata?: string | Upload['metadata']
+type StoredUpload = Omit<Upload, 'metadata' | 'sizeIsDeferred'> & {
+  metadata: string
 }
 
 const log = debug('tus-node-server:stores:azurestore')
@@ -132,15 +129,11 @@ export class AzureStore extends DataStore {
       throw ERRORS.FILE_NOT_FOUND
     }
     const storedUpload = JSON.parse(propertyData.metadata.upload) as StoredUpload
-    let metadata = storedUpload.metadata
     // Metadata is base64 encoded to avoid errors for non-ASCII characters
     // so we need to decode it separately
-    if (typeof metadata === 'string') {
-      metadata = metadata ? Metadata.parse(metadata) : {}
-    }
     const upload = new Upload({
       ...storedUpload,
-      metadata: metadata ?? {},
+      metadata: storedUpload.metadata ? Metadata.parse(storedUpload.metadata) : {},
     })
 
     await this.cache.set(appendBlobClient.url, upload)

--- a/packages/azure-store/src/test/index.ts
+++ b/packages/azure-store/src/test/index.ts
@@ -1,12 +1,30 @@
 import 'should'
 import {strict as assert} from 'node:assert'
 import path from 'node:path'
-import {ContainerClient} from '@azure/storage-blob'
+import {type AppendBlobClient, ContainerClient} from '@azure/storage-blob'
 import {AzureStore} from '@tus/azure-store'
+import {Metadata, type Upload} from '@tus/utils'
 import * as shared from '../../../utils/dist/test/stores.js'
 
 const fixturesPath = path.resolve('../', '../', 'test', 'fixtures')
 const storePath = path.resolve('../', '../', 'test', 'output', 'azure-store')
+
+type PersistedUpload = Pick<Upload, 'id' | 'size' | 'offset'> & {
+  metadata: string | Upload['metadata']
+}
+
+function storeWithPersistedUpload(upload: PersistedUpload) {
+  const appendBlobClient = {
+    url: 'https://example.com/container/persisted-upload',
+    getProperties: async () => ({metadata: {upload: JSON.stringify(upload)}}),
+  } as unknown as AppendBlobClient
+  const client = {
+    containerName: 'container',
+    getAppendBlobClient: () => appendBlobClient,
+  } as unknown as ContainerClient
+
+  return new AzureStore({client})
+}
 
 describe('AzureStore', () => {
   before(function () {
@@ -39,5 +57,48 @@ describe('AzureStore', () => {
     const store = new AzureStore({client})
 
     assert.ok(store)
+  })
+})
+
+describe('AzureStore persisted metadata', () => {
+  it('decodes TUS metadata loaded from Azure', async () => {
+    const metadata = {filename: '世界.pdf', is_confidential: null}
+    const store = storeWithPersistedUpload({
+      id: 'persisted-upload',
+      size: 42,
+      offset: 7,
+      metadata: Metadata.stringify(metadata),
+    })
+
+    const upload = await store.getUpload('persisted-upload')
+
+    assert.deepStrictEqual(upload.metadata, metadata)
+  })
+
+  it('restores empty persisted metadata', async () => {
+    const store = storeWithPersistedUpload({
+      id: 'persisted-upload',
+      size: 42,
+      offset: 7,
+      metadata: '',
+    })
+
+    const upload = await store.getUpload('persisted-upload')
+
+    assert.deepStrictEqual(upload.metadata, {})
+  })
+
+  it('preserves metadata stored before TUS encoding', async () => {
+    const metadata = {filename: 'legacy.pdf'}
+    const store = storeWithPersistedUpload({
+      id: 'persisted-upload',
+      size: 42,
+      offset: 7,
+      metadata,
+    })
+
+    const upload = await store.getUpload('persisted-upload')
+
+    assert.deepStrictEqual(upload.metadata, metadata)
   })
 })

--- a/packages/azure-store/src/test/index.ts
+++ b/packages/azure-store/src/test/index.ts
@@ -1,30 +1,13 @@
 import 'should'
 import {strict as assert} from 'node:assert'
 import path from 'node:path'
-import {type AppendBlobClient, ContainerClient} from '@azure/storage-blob'
+import {ContainerClient} from '@azure/storage-blob'
 import {AzureStore} from '@tus/azure-store'
-import {Metadata, type Upload} from '@tus/utils'
+import {Metadata} from '@tus/utils'
 import * as shared from '../../../utils/dist/test/stores.js'
 
 const fixturesPath = path.resolve('../', '../', 'test', 'fixtures')
 const storePath = path.resolve('../', '../', 'test', 'output', 'azure-store')
-
-type PersistedUpload = Pick<Upload, 'id' | 'size' | 'offset'> & {
-  metadata: string | Upload['metadata']
-}
-
-function storeWithPersistedUpload(upload: PersistedUpload) {
-  const appendBlobClient = {
-    url: 'https://example.com/container/persisted-upload',
-    getProperties: async () => ({metadata: {upload: JSON.stringify(upload)}}),
-  } as unknown as AppendBlobClient
-  const client = {
-    containerName: 'container',
-    getAppendBlobClient: () => appendBlobClient,
-  } as unknown as ContainerClient
-
-  return new AzureStore({client})
-}
 
 describe('AzureStore', () => {
   before(function () {
@@ -63,40 +46,20 @@ describe('AzureStore', () => {
 describe('AzureStore persisted metadata', () => {
   it('decodes TUS metadata loaded from Azure', async () => {
     const metadata = {filename: '世界.pdf', is_confidential: null}
-    const store = storeWithPersistedUpload({
+    const storedUpload = JSON.stringify({
       id: 'persisted-upload',
-      size: 42,
       offset: 7,
+      size: 42,
       metadata: Metadata.stringify(metadata),
     })
-
-    const upload = await store.getUpload('persisted-upload')
-
-    assert.deepStrictEqual(upload.metadata, metadata)
-  })
-
-  it('restores empty persisted metadata', async () => {
-    const store = storeWithPersistedUpload({
-      id: 'persisted-upload',
-      size: 42,
-      offset: 7,
-      metadata: '',
-    })
-
-    const upload = await store.getUpload('persisted-upload')
-
-    assert.deepStrictEqual(upload.metadata, {})
-  })
-
-  it('preserves metadata stored before TUS encoding', async () => {
-    const metadata = {filename: 'legacy.pdf'}
-    const store = storeWithPersistedUpload({
-      id: 'persisted-upload',
-      size: 42,
-      offset: 7,
-      metadata,
-    })
-
+    const client = {
+      containerName: 'container',
+      getAppendBlobClient: () => ({
+        url: 'https://example.com/container/persisted-upload',
+        getProperties: async () => ({metadata: {upload: storedUpload}}),
+      }),
+    } as unknown as ContainerClient
+    const store = new AzureStore({client})
     const upload = await store.getUpload('persisted-upload')
 
     assert.deepStrictEqual(upload.metadata, metadata)


### PR DESCRIPTION
## What changed

- decode the raw TUS metadata string when loading upload state from Azure Blob Storage
- model the persisted upload shape explicitly at the Azure storage boundary
- add focused cache-miss regression coverage
- add a patch changeset for `@tus/azure-store`

## Why

`saveMetadata` persists `upload.metadata` using `Metadata.stringify`, but `getMetadata` passed that string through `JSON.stringify` again before parsing it. The added JSON quotes made `Metadata.parse` reject otherwise valid metadata with `Metadata string is not valid`, preventing uploaded files from being retrieved after the in-memory cache was cold.

## Impact

Azure-backed uploads can be retrieved after a restart or cache miss, including uploads with non-ASCII metadata.

## Validation

- `npm test -w @tus/azure-store -- --grep 'AzureStore persisted metadata'`
- `npm run build`
- `npm run format:check`
- `npx biome check packages/azure-store/src/index.ts packages/azure-store/src/test/index.ts`
- `npx changeset status --since=main`
- thermo-nuclear code-quality review completed before commit

Closes #791
Supersedes #790
