### PR TITLE
@tus/s3-store: vendor semaphore implementation

### DIFF
--- a/.changeset/small-colts-juggle.md
+++ b/.changeset/small-colts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@tus/s3-store": patch
+---
+
+vendor semaphore implementation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1990,14 +1990,6 @@
         }
       }
     },
-    "node_modules/@shopify/semaphore": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/semaphore/-/semaphore-3.1.0.tgz",
-      "integrity": "sha512-LxonkiWEu12FbZhuOMhsdocpxCqm7By8C/2U9QgNuEoXUx2iMrlXjJv3p93RwfNC6TrdlNRo17gRer1z1309VQ==",
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -6283,7 +6275,6 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1045.0",
-        "@shopify/semaphore": "^3.1.0",
         "@tus/utils": "^0.7.0",
         "debug": "^4.3.4",
         "multistream": "^4.1.0"

--- a/packages/s3-store/package.json
+++ b/packages/s3-store/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",
-    "@shopify/semaphore": "^3.1.0",
     "@tus/utils": "^0.7.0",
     "debug": "^4.3.4",
     "multistream": "^4.1.0"

--- a/packages/s3-store/src/index.ts
+++ b/packages/s3-store/src/index.ts
@@ -17,7 +17,7 @@ import {
   MemoryKvStore,
 } from '@tus/utils'
 
-import {Semaphore, type Permit} from '@shopify/semaphore'
+import {Semaphore, type Permit} from './semaphore.js'
 import MultiStream from 'multistream'
 import crypto from 'node:crypto'
 import path from 'node:path'

--- a/packages/s3-store/src/semaphore.ts
+++ b/packages/s3-store/src/semaphore.ts
@@ -1,0 +1,87 @@
+/*
+ * Vendored from @shopify/semaphore 3.1.0:
+ * https://github.com/Shopify/quilt/blob/%40shopify/semaphore%403.1.0/packages/semaphore/src/Semaphore.ts
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018-present Shopify
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+type ReleaseCallback = () => Promise<unknown>
+
+export class Permit {
+  private onRelease: ReleaseCallback
+  private isReleased = false
+
+  constructor(onRelease: ReleaseCallback) {
+    this.onRelease = onRelease
+  }
+
+  async release() {
+    if (!this.isReleased) {
+      this.isReleased = true
+      await this.onRelease()
+    }
+  }
+}
+
+interface Deferred {
+  resolve(permit: Permit): void
+  promise: Promise<Permit>
+}
+
+export class Semaphore {
+  private availablePermits: number
+  private deferreds: Deferred[] = []
+
+  constructor(count: number) {
+    this.availablePermits = count
+  }
+
+  acquire(): Promise<Permit> {
+    if (this.availablePermits > 0) {
+      return Promise.resolve(this.createPermit())
+    } else {
+      const deferred = {} as Deferred
+      deferred.promise = new Promise((resolve) => {
+        deferred.resolve = resolve
+      })
+      this.deferreds.push(deferred)
+      return deferred.promise
+    }
+  }
+
+  private createPermit(): Permit {
+    this.availablePermits--
+
+    return new Permit(async (): Promise<void> => {
+      this.availablePermits++
+
+      if (this.deferreds.length > 0) {
+        const deferred = this.deferreds.shift()
+        if (deferred) {
+          deferred.resolve(this.createPermit())
+          await deferred.promise
+        }
+      }
+    })
+  }
+}

--- a/packages/s3-store/src/test/semaphore.ts
+++ b/packages/s3-store/src/test/semaphore.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+
+import {Permit, Semaphore} from '../semaphore.js'
+
+describe('Semaphore', () => {
+  it('limits the number of concurrently acquired permits', async () => {
+    const semaphore = new Semaphore(1)
+    const firstPermit = await semaphore.acquire()
+    let secondPermitAcquired = false
+
+    const secondPermitPromise = semaphore.acquire().then((permit) => {
+      secondPermitAcquired = true
+      return permit
+    })
+
+    await Promise.resolve()
+    assert.equal(secondPermitAcquired, false)
+
+    await firstPermit.release()
+    assert.ok((await secondPermitPromise) instanceof Permit)
+  })
+
+  it('resolves queued permit requests in FIFO order', async () => {
+    const semaphore = new Semaphore(1)
+    const firstPermit = await semaphore.acquire()
+    const acquired: number[] = []
+
+    const secondPermitPromise = semaphore.acquire().then((permit) => {
+      acquired.push(2)
+      return permit
+    })
+    const thirdPermitPromise = semaphore.acquire().then((permit) => {
+      acquired.push(3)
+      return permit
+    })
+
+    await firstPermit.release()
+    const secondPermit = await secondPermitPromise
+    assert.deepEqual(acquired, [2])
+
+    await secondPermit.release()
+    await thirdPermitPromise
+    assert.deepEqual(acquired, [2, 3])
+  })
+})
+
+describe('Permit', () => {
+  it('only releases its semaphore once', async () => {
+    const semaphore = new Semaphore(1)
+    const firstPermit = await semaphore.acquire()
+    const secondPermitPromise = semaphore.acquire()
+    let thirdPermitAcquired = false
+
+    const thirdPermitPromise = semaphore.acquire().then((permit) => {
+      thirdPermitAcquired = true
+      return permit
+    })
+
+    await firstPermit.release()
+    await firstPermit.release()
+
+    const secondPermit = await secondPermitPromise
+    await Promise.resolve()
+    assert.equal(thirdPermitAcquired, false)
+
+    await secondPermit.release()
+    assert.ok((await thirdPermitPromise) instanceof Permit)
+  })
+})


### PR DESCRIPTION
## Why

`@shopify/semaphore@3.1.0` is archived and emits a deprecation warning, but its
small counting-semaphore implementation has been stable for `@tus/s3-store`.
Vendoring that implementation removes a runtime dependency without changing the
multipart-upload concurrency contract.

This supersedes #829 and follows the maintainer suggestion there to keep the
existing implementation instead of replacing it with another package.

## What

- Copy the `Permit` and `Semaphore` implementation from the exact
  `@shopify/semaphore@3.1.0` tag into `@tus/s3-store`.
- Retain Shopify's full MIT copyright and license notice with the source.
- Switch the S3 store to the local module.
- Remove `@shopify/semaphore` from the package manifest and lockfile.
- Add focused tests for concurrency limits, FIFO permit handoff, and idempotent
  release.

The vendored module keeps the upstream runtime behavior and API. Type annotations
and impossible-state checks are tightened to satisfy this repository's lint rules.

## Impact

`@tus/s3-store` has one fewer runtime dependency and consumers no longer see the
archived-package deprecation. There is no public API or behavioral change.

## Verified

- `npm run build`
- `npm run format:check`
- `npx biome lint packages/s3-store/src/semaphore.ts packages/s3-store/src/test/semaphore.ts packages/s3-store/src/index.ts`
- `npx mocha 'packages/s3-store/dist/test/semaphore.js' --exit --timeout 40000`
  (3 passing)
- `npm ls @shopify/semaphore --all` (empty)
- `npm pack --dry-run -w @tus/s3-store` (vendored source and compiled module
  included)

No changeset is included because this is an internal dependency cleanup with no
public behavior change.
