### PR TITLE
@tus/server: fix postHandler onUploadFinish header precedence

### DIFF
--- a/.changeset/wild-foxes-invite.md
+++ b/.changeset/wild-foxes-invite.md
@@ -1,0 +1,5 @@
+---
+"@tus/server": patch
+---
+
+Ensure `PostHandler` `onUploadFinish` hook headers override response defaults correctly.

--- a/packages/server/src/handlers/PostHandler.ts
+++ b/packages/server/src/handlers/PostHandler.ts
@@ -147,7 +147,7 @@ export class PostHandler extends BaseHandler {
         if (patch.status_code) responseData.status = patch.status_code
         if (patch.body) responseData.body = patch.body
         if (patch.headers)
-          responseData.headers = Object.assign(patch.headers, responseData.headers)
+          responseData.headers = Object.assign(responseData.headers, patch.headers)
       } catch (error) {
         log(`onUploadFinish: ${error.body}`)
         throw error

--- a/packages/server/src/test/PostHandler.test.ts
+++ b/packages/server/src/test/PostHandler.test.ts
@@ -374,6 +374,24 @@ describe('PostHandler', () => {
         assert.equal(upload.size, 1024)
       })
 
+      it('should let onUploadFinish override response headers without mutating them', async () => {
+        const store = sinon.createStubInstance(DataStore)
+        const hookHeaders = Object.freeze({'x-test': 'overridden'})
+        const handler = new PostHandler(store, {
+          path: '/test/output',
+          locker: new MemoryLocker(),
+          onUploadFinish: async () => ({headers: hookHeaders}),
+        })
+
+        const req = new Request('https://example.com/test/output', {
+          headers: {'upload-length': '0', host: 'localhost:3000'},
+        })
+        const res = await handler.send(req, context, new Headers({'x-test': 'default'}))
+
+        assert.equal(res.headers.get('x-test'), 'overridden')
+        assert.deepEqual(hookHeaders, {'x-test': 'overridden'})
+      })
+
       it('should call onUploadFinish hook for empty file without content-type', async () => {
         const store = sinon.createStubInstance(DataStore)
         const spy = sinon.stub().resolvesArg(1)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tus/tus-node-server/pull/854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->