### PR TITLE
@tus/server: avoid unnecessary POST_RECEIVE throttling

### DIFF
--- a/.changeset/mean-mangos-go.md
+++ b/.changeset/mean-mangos-go.md
@@ -1,0 +1,6 @@
+---
+"@tus/server": patch
+---
+
+Only install progress tracking when POST_RECEIVE listeners present.
+Cancel pending trailing calls before writes settle to prevent late events.

--- a/.changeset/mean-mangos-go.md
+++ b/.changeset/mean-mangos-go.md
@@ -2,5 +2,6 @@
 "@tus/server": patch
 ---
 
-Only install progress tracking when POST_RECEIVE listeners present.
-Cancel pending trailing calls before writes settle to prevent late events.
+Stop delayed `POST_RECEIVE` events from firing after an upload write settles, and skip
+progress tracking for writes that start without `POST_RECEIVE` listeners. Use `POST_FINISH`
+when a terminal upload notification is required.

--- a/packages/server/src/handlers/BaseHandler.ts
+++ b/packages/server/src/handlers/BaseHandler.ts
@@ -184,19 +184,23 @@ export class BaseHandler extends EventEmitter {
         reject(err.name === 'AbortError' ? ERRORS.ABORTED : err)
       })
 
-      const postReceive = throttle(
-        (offset: number) => {
-          this.emit(EVENTS.POST_RECEIVE, nodeStream, {...upload, offset})
-        },
-        this.options.postReceiveInterval,
-        {leading: false}
-      )
-
-      let tempOffset = upload.offset
-      proxy.on('data', (chunk: Buffer) => {
-        tempOffset += chunk.byteLength
-        postReceive(tempOffset)
-      })
+      const postReceive =
+        this.listenerCount(EVENTS.POST_RECEIVE) > 0
+          ? throttle(
+              (offset: number) => {
+                this.emit(EVENTS.POST_RECEIVE, nodeStream, {...upload, offset})
+              },
+              this.options.postReceiveInterval,
+              {leading: false}
+            )
+          : undefined
+      if (postReceive) {
+        let tempOffset = upload.offset
+        proxy.on('data', (chunk: Buffer) => {
+          tempOffset += chunk.byteLength
+          postReceive(tempOffset)
+        })
+      }
 
       // Pipe the request stream through the proxy. We use the proxy instead of the request stream directly
       // to ensure that errors in the pipeline do not cause the request stream to be destroyed,
@@ -209,11 +213,11 @@ export class BaseHandler extends EventEmitter {
             return this.store.write(stream as StreamLimiter, upload.id, upload.offset)
           }
         )
-        .then(resolve)
-        .catch(reject)
         .finally(() => {
+          postReceive?.cancel()
           context.signal.removeEventListener('abort', onAbort)
         })
+        .then(resolve, reject)
     })
   }
 

--- a/packages/server/src/handlers/BaseHandler.ts
+++ b/packages/server/src/handlers/BaseHandler.ts
@@ -144,81 +144,74 @@ export class BaseHandler extends EventEmitter {
     return lock
   }
 
-  protected writeToStore(
+  protected async writeToStore(
     webStream: ReadableStream | null,
     upload: Upload,
     maxFileSize: number,
     context: CancellationContext
   ) {
-    // biome-ignore lint/suspicious/noAsyncPromiseExecutor: async needed for sequential stream operations
-    return new Promise<number>(async (resolve, reject) => {
-      // Abort early if the operation has been cancelled.
-      if (context.signal.aborted) {
-        reject(ERRORS.ABORTED)
-        return
+    // Abort early if the operation has been cancelled.
+    if (context.signal.aborted) {
+      throw ERRORS.ABORTED
+    }
+
+    // Create a PassThrough stream as a proxy to manage the request stream.
+    // This allows for aborting the write process without affecting the incoming request stream.
+    const proxy = new PassThrough()
+    const nodeStream = webStream ? Readable.fromWeb(webStream) : Readable.from([])
+
+    // Ignore errors on the data stream to prevent crashes from client disconnections.
+    // The pipeline handles errors emitted by the proxy stream instead.
+    nodeStream.on('error', () => {
+      /* do nothing */
+    })
+
+    // gracefully terminate the proxy stream when the request is aborted
+    const onAbort = () => {
+      nodeStream.unpipe(proxy)
+
+      if (!proxy.closed) {
+        proxy.end()
       }
+    }
+    context.signal.addEventListener('abort', onAbort, {once: true})
 
-      // Create a PassThrough stream as a proxy to manage the request stream.
-      // This allows for aborting the write process without affecting the incoming request stream.
-      const proxy = new PassThrough()
-      const nodeStream = webStream ? Readable.fromWeb(webStream) : Readable.from([])
-
-      // Ignore errors on the data stream to prevent crashes from client disconnections
-      // We handle errors on the proxy stream instead.
-      nodeStream.on('error', () => {
-        /* do nothing */
+    const postReceive =
+      this.listenerCount(EVENTS.POST_RECEIVE) > 0
+        ? throttle(
+            (offset: number) => {
+              this.emit(EVENTS.POST_RECEIVE, nodeStream, {...upload, offset})
+            },
+            this.options.postReceiveInterval,
+            {leading: false}
+          )
+        : undefined
+    if (postReceive) {
+      let tempOffset = upload.offset
+      proxy.on('data', (chunk: Buffer) => {
+        tempOffset += chunk.byteLength
+        postReceive(tempOffset)
       })
+    }
 
-      // gracefully terminate the proxy stream when the request is aborted
-      const onAbort = () => {
-        nodeStream.unpipe(proxy)
-
-        if (!proxy.closed) {
-          proxy.end()
-        }
-      }
-      context.signal.addEventListener('abort', onAbort, {once: true})
-
-      proxy.on('error', (err) => {
-        nodeStream.unpipe(proxy)
-        reject(err.name === 'AbortError' ? ERRORS.ABORTED : err)
-      })
-
-      const postReceive =
-        this.listenerCount(EVENTS.POST_RECEIVE) > 0
-          ? throttle(
-              (offset: number) => {
-                this.emit(EVENTS.POST_RECEIVE, nodeStream, {...upload, offset})
-              },
-              this.options.postReceiveInterval,
-              {leading: false}
-            )
-          : undefined
-      if (postReceive) {
-        let tempOffset = upload.offset
-        proxy.on('data', (chunk: Buffer) => {
-          tempOffset += chunk.byteLength
-          postReceive(tempOffset)
-        })
-      }
-
+    try {
       // Pipe the request stream through the proxy. We use the proxy instead of the request stream directly
       // to ensure that errors in the pipeline do not cause the request stream to be destroyed,
       // which would result in a socket hangup error for the client.
-      stream
-        .pipeline(
-          nodeStream.pipe(proxy),
-          new StreamLimiter(maxFileSize),
-          async (stream) => {
-            return this.store.write(stream as StreamLimiter, upload.id, upload.offset)
-          }
-        )
-        .finally(() => {
-          postReceive?.cancel()
-          context.signal.removeEventListener('abort', onAbort)
-        })
-        .then(resolve, reject)
-    })
+      return await stream.pipeline(
+        nodeStream.pipe(proxy),
+        new StreamLimiter(maxFileSize),
+        async (stream) => {
+          return this.store.write(stream as StreamLimiter, upload.id, upload.offset)
+        }
+      )
+    } catch (error) {
+      nodeStream.unpipe(proxy)
+      throw error instanceof Error && error.name === 'AbortError' ? ERRORS.ABORTED : error
+    } finally {
+      postReceive?.cancel()
+      context.signal.removeEventListener('abort', onAbort)
+    }
   }
 
   getConfiguredMaxSize(req: Request, id: string | null) {

--- a/packages/server/src/test/BaseHandler.test.ts
+++ b/packages/server/src/test/BaseHandler.test.ts
@@ -140,15 +140,27 @@ const consumeStoreWrites = (
   store: sinon.SinonStubbedInstance<DataStore>,
   initialOffset = 0
 ) => {
-  let chunkCount = 0
   let offset = initialOffset
-  const chunkWaiters = new Map<number, () => void>()
+  const chunks: Promise<void>[] = []
+  const resolvers: Array<() => void> = []
+
+  const ensure = (index: number) => {
+    while (chunks.length <= index) {
+      chunks.push(
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve)
+        })
+      )
+    }
+  }
 
   store.write.callsFake(async (readable: Readable) => {
+    let index = 0
     for await (const chunk of readable) {
       offset += (chunk as Buffer).byteLength
-      chunkCount++
-      chunkWaiters.get(chunkCount)?.()
+      ensure(index)
+      resolvers[index]?.()
+      index++
     }
 
     return offset
@@ -156,13 +168,8 @@ const consumeStoreWrites = (
 
   return {
     waitForChunk(target: number) {
-      if (chunkCount >= target) {
-        return Promise.resolve()
-      }
-
-      return new Promise<void>((resolve) => {
-        chunkWaiters.set(target, resolve)
-      })
+      ensure(target - 1)
+      return chunks[target - 1]
     },
   }
 }
@@ -246,34 +253,6 @@ describe('BaseHandler.writeToStore', () => {
     assert.equal(emit.withArgs(EVENTS.POST_RECEIVE).callCount, 0)
   })
 
-  it('does not start progress tracking for a listener added during a write', async () => {
-    const {handler, store} = createHandler()
-    const {waitForChunk} = consumeStoreWrites(store)
-    const context = createContext()
-    const {controller, webStream} = createControlledStream()
-
-    const write = handler.writeToStoreForTest(
-      webStream,
-      new Upload({id: 'late-listener', offset: 0}),
-      maxFileSize,
-      context
-    )
-    controller.enqueue(Buffer.alloc(4))
-    await waitForChunk(1)
-
-    const postReceive = sinon.spy()
-    handler.on(EVENTS.POST_RECEIVE, postReceive)
-
-    controller.enqueue(Buffer.alloc(3))
-    await waitForChunk(2)
-
-    assert.equal(clock.countTimers(), 0)
-    assert.equal(postReceive.called, false)
-
-    controller.close()
-    assert.equal(await write, 7)
-  })
-
   it('keeps intermediate progress without a terminal trailing event', async () => {
     const {handler, store} = createHandler()
     const {waitForChunk} = consumeStoreWrites(store, 10)
@@ -344,6 +323,22 @@ describe('BaseHandler.writeToStore', () => {
 
     assert.equal(clock.countTimers(), 0)
     assert.equal(postReceive.called, false)
+  })
+
+  it('rejects when converting the web stream throws synchronously', async () => {
+    const {handler} = createHandler()
+    const context = createContext()
+
+    await assert.rejects(
+      handler.writeToStoreForTest(
+        // @ts-expect-error testing invalid input at the runtime boundary
+        {},
+        new Upload({id: 'invalid-stream', offset: 0}),
+        maxFileSize,
+        context
+      ),
+      {code: 'ERR_INVALID_ARG_TYPE'}
+    )
   })
 
   it('cancels pending POST_RECEIVE progress after an abort', async () => {

--- a/packages/server/src/test/BaseHandler.test.ts
+++ b/packages/server/src/test/BaseHandler.test.ts
@@ -1,8 +1,12 @@
 import {strict as assert} from 'node:assert'
+import type {Readable} from 'node:stream'
+
+import {MemoryLocker} from '@tus/server'
+import {type CancellationContext, DataStore, EVENTS, Upload} from '@tus/utils'
+import sinon from 'sinon'
 
 import {BaseHandler} from '../handlers/BaseHandler.js'
-import {DataStore} from '@tus/utils'
-import {MemoryLocker} from '@tus/server'
+import {createContext} from './utils.js'
 
 describe('BaseHandler', () => {
   const store = new DataStore()
@@ -103,5 +107,311 @@ describe('BaseHandler', () => {
     const req = new Request('http://example.com/upload/1234')
     const url = handler.getFileIdFromRequest(req)
     assert.equal(url, '1234-custom')
+  })
+})
+
+class TestHandler extends BaseHandler {
+  writeToStoreForTest(
+    webStream: ReadableStream | null,
+    upload: Upload,
+    maxFileSize: number,
+    context: CancellationContext
+  ) {
+    return this.writeToStore(webStream, upload, maxFileSize, context)
+  }
+}
+
+const createControlledStream = () => {
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined
+  const webStream = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController
+    },
+  })
+
+  if (!controller) {
+    throw new Error('ReadableStream did not initialize synchronously')
+  }
+
+  return {controller, webStream}
+}
+
+const consumeStoreWrites = (
+  store: sinon.SinonStubbedInstance<DataStore>,
+  initialOffset = 0
+) => {
+  let chunkCount = 0
+  let offset = initialOffset
+  const chunkWaiters = new Map<number, () => void>()
+
+  store.write.callsFake(async (readable: Readable) => {
+    for await (const chunk of readable) {
+      offset += (chunk as Buffer).byteLength
+      chunkCount++
+      chunkWaiters.get(chunkCount)?.()
+    }
+
+    return offset
+  })
+
+  return {
+    waitForChunk(target: number) {
+      if (chunkCount >= target) {
+        return Promise.resolve()
+      }
+
+      return new Promise<void>((resolve) => {
+        chunkWaiters.set(target, resolve)
+      })
+    },
+  }
+}
+
+describe('BaseHandler.writeToStore', () => {
+  const interval = 100
+  const maxFileSize = Number.MAX_SAFE_INTEGER
+  let clock: sinon.SinonFakeTimers
+
+  before(() => {
+    clock = sinon.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'Date'],
+    })
+  })
+
+  afterEach(() => {
+    clock.reset()
+  })
+
+  after(() => {
+    clock.restore()
+  })
+
+  const createHandler = () => {
+    const store = sinon.createStubInstance(DataStore)
+    const handler = new TestHandler(store, {
+      path: '/files',
+      locker: new MemoryLocker(),
+      postReceiveInterval: interval,
+    })
+
+    return {handler, store}
+  }
+
+  it('does not emit late POST_RECEIVE progress after a short successful write', async () => {
+    const {handler, store} = createHandler()
+    consumeStoreWrites(store)
+    const postReceive = sinon.spy()
+    handler.on(EVENTS.POST_RECEIVE, postReceive)
+    const context = createContext()
+    const webStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Buffer.from('short upload'))
+        controller.close()
+      },
+    })
+
+    await handler.writeToStoreForTest(
+      webStream,
+      new Upload({id: 'short', offset: 0}),
+      maxFileSize,
+      context
+    )
+
+    assert.equal(clock.countTimers(), 0)
+    assert.equal(postReceive.called, false)
+  })
+
+  it('does not schedule or emit POST_RECEIVE progress without listeners', async () => {
+    const {handler, store} = createHandler()
+    const {waitForChunk} = consumeStoreWrites(store)
+    const emit = sinon.spy(handler, 'emit')
+    const context = createContext()
+    const {controller, webStream} = createControlledStream()
+
+    const write = handler.writeToStoreForTest(
+      webStream,
+      new Upload({id: 'no-listener', offset: 0}),
+      maxFileSize,
+      context
+    )
+    controller.enqueue(Buffer.from('chunk'))
+    await waitForChunk(1)
+
+    assert.equal(clock.countTimers(), 0)
+
+    controller.close()
+    await write
+
+    assert.equal(clock.countTimers(), 0)
+    assert.equal(emit.withArgs(EVENTS.POST_RECEIVE).callCount, 0)
+  })
+
+  it('does not start progress tracking for a listener added during a write', async () => {
+    const {handler, store} = createHandler()
+    const {waitForChunk} = consumeStoreWrites(store)
+    const context = createContext()
+    const {controller, webStream} = createControlledStream()
+
+    const write = handler.writeToStoreForTest(
+      webStream,
+      new Upload({id: 'late-listener', offset: 0}),
+      maxFileSize,
+      context
+    )
+    controller.enqueue(Buffer.alloc(4))
+    await waitForChunk(1)
+
+    const postReceive = sinon.spy()
+    handler.on(EVENTS.POST_RECEIVE, postReceive)
+
+    controller.enqueue(Buffer.alloc(3))
+    await waitForChunk(2)
+
+    assert.equal(clock.countTimers(), 0)
+    assert.equal(postReceive.called, false)
+
+    controller.close()
+    assert.equal(await write, 7)
+  })
+
+  it('keeps intermediate progress without a terminal trailing event', async () => {
+    const {handler, store} = createHandler()
+    const {waitForChunk} = consumeStoreWrites(store, 10)
+    const offsets: number[] = []
+    handler.on(EVENTS.POST_RECEIVE, (_stream, upload) => {
+      offsets.push(upload.offset)
+    })
+    const context = createContext()
+    const {controller, webStream} = createControlledStream()
+
+    const write = handler.writeToStoreForTest(
+      webStream,
+      new Upload({id: 'long', offset: 10}),
+      maxFileSize,
+      context
+    )
+    controller.enqueue(Buffer.alloc(4))
+    await waitForChunk(1)
+    await clock.tickAsync(interval)
+
+    assert.deepEqual(offsets, [14])
+
+    controller.enqueue(Buffer.alloc(3))
+    await waitForChunk(2)
+    await clock.tickAsync(interval)
+
+    assert.deepEqual(offsets, [14, 17])
+
+    controller.enqueue(Buffer.alloc(2))
+    await waitForChunk(3)
+    await clock.tickAsync(interval)
+
+    assert.deepEqual(offsets, [14, 17, 19])
+
+    controller.close()
+    assert.equal(await write, 19)
+    assert.equal(clock.countTimers(), 0)
+    assert.deepEqual(offsets, [14, 17, 19])
+  })
+
+  it('cancels pending POST_RECEIVE progress after a store error', async () => {
+    const {handler, store} = createHandler()
+    const error = new Error('store failed')
+    store.write.callsFake(async (readable: Readable) => {
+      for await (const _chunk of readable) {
+        throw error
+      }
+      return 0
+    })
+    const postReceive = sinon.spy()
+    handler.on(EVENTS.POST_RECEIVE, postReceive)
+    const context = createContext()
+    const webStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Buffer.from('chunk'))
+        controller.close()
+      },
+    })
+
+    await assert.rejects(
+      handler.writeToStoreForTest(
+        webStream,
+        new Upload({id: 'error', offset: 0}),
+        maxFileSize,
+        context
+      )
+    )
+
+    assert.equal(clock.countTimers(), 0)
+    assert.equal(postReceive.called, false)
+  })
+
+  it('cancels pending POST_RECEIVE progress after an abort', async () => {
+    const {handler, store} = createHandler()
+    const {waitForChunk} = consumeStoreWrites(store)
+    const postReceive = sinon.spy()
+    handler.on(EVENTS.POST_RECEIVE, postReceive)
+    const context = createContext()
+    const {controller, webStream} = createControlledStream()
+
+    const write = handler.writeToStoreForTest(
+      webStream,
+      new Upload({id: 'abort', offset: 0}),
+      maxFileSize,
+      context
+    )
+    controller.enqueue(Buffer.from('chunk'))
+    await waitForChunk(1)
+
+    assert.equal(clock.countTimers(), 1)
+
+    context.abort()
+    controller.close()
+    assert.equal(await write, 5)
+
+    assert.equal(clock.countTimers(), 0)
+    assert.equal(postReceive.called, false)
+  })
+
+  it('emits the last observed offset while a write is stalled', async () => {
+    const {handler, store} = createHandler()
+    const {waitForChunk} = consumeStoreWrites(store, 7)
+    const offsets: number[] = []
+    handler.on(EVENTS.POST_RECEIVE, (_stream, upload) => {
+      offsets.push(upload.offset)
+    })
+    const context = createContext()
+    const {controller, webStream} = createControlledStream()
+    let settled = false
+
+    const write = handler.writeToStoreForTest(
+      webStream,
+      new Upload({id: 'stalled', offset: 7}),
+      maxFileSize,
+      context
+    )
+    write.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    controller.enqueue(Buffer.alloc(5))
+    await waitForChunk(1)
+
+    await clock.tickAsync(interval - 1)
+    assert.deepEqual(offsets, [])
+    assert.equal(settled, false)
+
+    await clock.tickAsync(1)
+    assert.deepEqual(offsets, [12])
+    assert.equal(settled, false)
+
+    controller.close()
+    await write
+
+    assert.equal(clock.countTimers(), 0)
   })
 })

--- a/packages/server/src/test/BaseHandler.test.ts
+++ b/packages/server/src/test/BaseHandler.test.ts
@@ -325,20 +325,29 @@ describe('BaseHandler.writeToStore', () => {
     assert.equal(postReceive.called, false)
   })
 
-  it('rejects when converting the web stream throws synchronously', async () => {
+  it('rejects when the web stream is already locked', async () => {
     const {handler} = createHandler()
     const context = createContext()
+    const webStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+    const reader = webStream.getReader()
 
-    await assert.rejects(
-      handler.writeToStoreForTest(
-        // @ts-expect-error testing invalid input at the runtime boundary
-        {},
-        new Upload({id: 'invalid-stream', offset: 0}),
-        maxFileSize,
-        context
-      ),
-      {code: 'ERR_INVALID_ARG_TYPE'}
-    )
+    try {
+      await assert.rejects(
+        handler.writeToStoreForTest(
+          webStream,
+          new Upload({id: 'locked-stream', offset: 0}),
+          maxFileSize,
+          context
+        ),
+        TypeError
+      )
+    } finally {
+      reader.releaseLock()
+    }
   })
 
   it('cancels pending POST_RECEIVE progress after an abort', async () => {
@@ -366,47 +375,5 @@ describe('BaseHandler.writeToStore', () => {
 
     assert.equal(clock.countTimers(), 0)
     assert.equal(postReceive.called, false)
-  })
-
-  it('emits the last observed offset while a write is stalled', async () => {
-    const {handler, store} = createHandler()
-    const {waitForChunk} = consumeStoreWrites(store, 7)
-    const offsets: number[] = []
-    handler.on(EVENTS.POST_RECEIVE, (_stream, upload) => {
-      offsets.push(upload.offset)
-    })
-    const context = createContext()
-    const {controller, webStream} = createControlledStream()
-    let settled = false
-
-    const write = handler.writeToStoreForTest(
-      webStream,
-      new Upload({id: 'stalled', offset: 7}),
-      maxFileSize,
-      context
-    )
-    write.then(
-      () => {
-        settled = true
-      },
-      () => {
-        settled = true
-      }
-    )
-    controller.enqueue(Buffer.alloc(5))
-    await waitForChunk(1)
-
-    await clock.tickAsync(interval - 1)
-    assert.deepEqual(offsets, [])
-    assert.equal(settled, false)
-
-    await clock.tickAsync(1)
-    assert.deepEqual(offsets, [12])
-    assert.equal(settled, false)
-
-    controller.close()
-    await write
-
-    assert.equal(clock.countTimers(), 0)
   })
 })


### PR DESCRIPTION
* avoid its overhead when no listeners exist
* cancel pending trailing timers when uploads settle
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tus/tus-node-server/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->