### PR TITLE
@tus/s3-store: map missing S3 resources to 404

### DIFF
--- a/.changeset/calm-pandas-terminate.md
+++ b/.changeset/calm-pandas-terminate.md
@@ -1,0 +1,5 @@
+---
+"@tus/s3-store": patch
+---
+
+Return a file-not-found error when S3 reports that an upload or object does not exist

--- a/packages/s3-store/src/index.ts
+++ b/packages/s3-store/src/index.ts
@@ -4,7 +4,7 @@ import stream, {promises as streamProm} from 'node:stream'
 import type {Readable} from 'node:stream'
 
 import type AWS from '@aws-sdk/client-s3'
-import {NoSuchKey, NotFound, S3, type S3ClientConfig} from '@aws-sdk/client-s3'
+import {S3, type S3ClientConfig} from '@aws-sdk/client-s3'
 import debug from 'debug'
 
 import {
@@ -57,6 +57,23 @@ export type MetadataValue = {
 
 function calcOffsetFromParts(parts?: Array<AWS.Part>) {
   return parts && parts.length > 0 ? parts.reduce((a, b) => a + (b.Size ?? 0), 0) : 0
+}
+
+const S3_NOT_FOUND_ERROR_CODES = new Set(['NotFound', 'NoSuchKey', 'NoSuchUpload'])
+
+function isS3NotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+
+  return (
+    ('name' in error &&
+      typeof error.name === 'string' &&
+      S3_NOT_FOUND_ERROR_CODES.has(error.name)) ||
+    ('Code' in error &&
+      typeof error.Code === 'string' &&
+      S3_NOT_FOUND_ERROR_CODES.has(error.Code))
+  )
 }
 
 // Implementation (based on https://github.com/tus/tusd/blob/master/s3store/s3store.go)
@@ -326,7 +343,7 @@ export class S3Store extends DataStore {
       })
       return data.Body as Readable
     } catch (error) {
-      if (error instanceof NoSuchKey) {
+      if (isS3NotFoundError(error)) {
         return undefined
       }
 
@@ -342,7 +359,7 @@ export class S3Store extends DataStore {
       })
       return data.ContentLength
     } catch (error) {
-      if (error instanceof NotFound) {
+      if (isS3NotFoundError(error)) {
         return undefined
       }
       throw error
@@ -662,7 +679,7 @@ export class S3Store extends DataStore {
       // completed and therefore can ensure the the offset is the size.
       // AWS S3 returns NoSuchUpload, but other implementations, such as DigitalOcean
       // Spaces, can also return NoSuchKey.
-      if (error.Code === 'NoSuchUpload' || error.Code === 'NoSuchKey') {
+      if (isS3NotFoundError(error)) {
         return new Upload({
           ...metadata.file,
           offset: metadata.file.size as number,
@@ -708,7 +725,7 @@ export class S3Store extends DataStore {
         })
       }
     } catch (error) {
-      if (error?.code && ['NotFound', 'NoSuchKey', 'NoSuchUpload'].includes(error.Code)) {
+      if (isS3NotFoundError(error)) {
         log('remove: No file found.', error)
         throw ERRORS.FILE_NOT_FOUND
       }

--- a/packages/s3-store/src/test/index.ts
+++ b/packages/s3-store/src/test/index.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {Readable} from 'node:stream'
 import stream from 'node:stream/promises'
 
+import {NoSuchUpload} from '@aws-sdk/client-s3'
 import sinon from 'sinon'
 
 import {S3Store} from '@tus/s3-store'
@@ -280,6 +281,28 @@ describe('S3DataStore', () => {
     } catch (error) {
       assert.fail(`Zero byte file was not uploaded to S3: ${error.message}`)
     }
+  })
+
+  it('should report a missing multipart upload as a missing file when removing it', async function () {
+    const store = this.datastore as S3Store
+    const id = shared.testId('missing-multipart-upload')
+
+    // @ts-expect-error protected method
+    sinon.stub(store, 'getMetadata').resolves({
+      file: new Upload({id, size: 1, offset: 1}),
+      'upload-id': 'missing-upload-id',
+      'tus-version': '1.0.0',
+    })
+
+    // @ts-expect-error protected property
+    sinon.stub(store.client, 'abortMultipartUpload').rejects(
+      new NoSuchUpload({
+        $metadata: {httpStatusCode: 404},
+        message: 'The specified upload does not exist.',
+      })
+    )
+
+    await assert.rejects(store.remove(id), {status_code: 404})
   })
 
   it('should use default maxMultipartParts when not specified', () => {

--- a/packages/utils/src/test/stores.ts
+++ b/packages/utils/src/test/stores.ts
@@ -119,8 +119,8 @@ export const shouldRemoveUploads = () => {
       assert.equal(this.datastore.hasExtension('termination'), true)
     })
 
-    it('should reject when the file does not exist', function () {
-      return this.datastore.remove('doesnt_exist').should.be.rejected()
+    it('should reject with file not found when the file does not exist', async function () {
+      await assert.rejects(this.datastore.remove('doesnt_exist'), {status_code: 404})
     })
 
     it('should delete the file when it does exist', async function () {


### PR DESCRIPTION
Fixes #856.

## Summary

- classify missing S3 uploads and objects using both AWS SDK v3 `name` and S3 REST-XML `Code`
- map `NoSuchUpload` from termination to `ERRORS.FILE_NOT_FOUND`
- use the same null-safe classifier across existing S3 missing-resource paths
- add a regression test using the SDK's real `NoSuchUpload` exception
- strengthen the shared datastore test to require a 404 for missing files

## Validation

Per repository guidance, validation is delegated to CI rather than run locally.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tus/tus-node-server/pull/859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->