### PR TITLE
@tus/server: validate proposed merges in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,18 @@ on:
     paths-ignore:
       - "**.md"
       - ".changeset/**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**.md"
+      - ".changeset/**"
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - "**.md"
       - ".changeset/**"
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}--${{ github.event_name == 'pull_request_target' && format('pr#{0}', github.event.pull_request.number) || github.ref }}
@@ -23,8 +30,10 @@ permissions:
   pull-requests: read
 
 jobs:
-  # Basic validation job - runs for all PRs and pushes without secrets
+  # Validate the proposed merge in an unprivileged pull_request workflow.
+  # pull_request_target is reserved for the environment-gated secret tests.
   basic-validation:
+    if: github.event_name != 'pull_request_target'
     name: Build and lint
     runs-on: ubuntu-latest
 
@@ -53,6 +62,7 @@ jobs:
 
   # Integration tests with secrets - requires approval for external PRs
   tests:
+    if: github.event_name != 'pull_request'
     name: Tests
     runs-on: ubuntu-latest
     # SECURITY: Use environment protection for external contributors only
@@ -68,8 +78,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
         with:
-          # Environment protection provides security - we can safely checkout PR code
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Test the event's pinned proposed merge, including the current base.
+          # External PRs cannot reach this step until the environment is approved.
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           allow-unsafe-pr-checkout: true
 
       - name: Decrypt keyfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,4 @@
 name: CI
-# SECURITY: Uses environment protection for external PRs instead of unsafe "safe to test" labels.
-# Environment protection provides secure manual approval tied to specific commits,
-# eliminating race conditions and ensuring maintainer review before secrets access.
 on:
   push:
     branches: [main]
@@ -13,16 +10,11 @@ on:
     paths-ignore:
       - "**.md"
       - ".changeset/**"
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    paths-ignore:
-      - "**.md"
-      - ".changeset/**"
   merge_group:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}--${{ github.event_name == 'pull_request_target' && format('pr#{0}', github.event.pull_request.number) || github.ref }}
+  group: ${{ github.workflow }}--${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -30,10 +22,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  # Validate the proposed merge in an unprivileged pull_request workflow.
-  # pull_request_target is reserved for the environment-gated secret tests.
   basic-validation:
-    if: github.event_name != 'pull_request_target'
     name: Build and lint
     runs-on: ubuntu-latest
 
@@ -59,56 +48,3 @@ jobs:
 
       - name: Run linters
         run: npm run lint
-
-  # Integration tests with secrets - requires approval for external PRs
-  tests:
-    if: github.event_name != 'pull_request'
-    name: Tests
-    runs-on: ubuntu-latest
-    # SECURITY: Use environment protection for external contributors only
-    # Push events and internal PRs run without environment protection
-    # External PRs require manual approval via 'external-testing' environment
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external-testing' || '' }}
-    # Run tests with secrets for all triggers:
-    # 1. Push to main (trusted)
-    # 2. Internal PRs (trusted)
-    # 3. External PRs (requires manual approval via environment protection)
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v7
-        with:
-          # Test GitHub's proposed merge, including the current base.
-          # If the merge ref does not exist, checkout fails instead of testing the base.
-          # External PRs cannot reach this step until the environment is approved.
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
-          allow-unsafe-pr-checkout: true
-
-      - name: Decrypt keyfile
-        run: ./.github/scripts/decrypt_secret.sh
-        env:
-          KEYFILE_PASSPHRASE: ${{secrets.KEYFILE_PASSPHRASE}}
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20.x
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci --no-fund --no-audit
-
-      - name: Build
-        run: npm run build
-
-      - name: Run tests
-        run: npm run test
-        env:
-          AWS_BUCKET: ${{secrets.AWS_BUCKET}}
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-          AZURE_ACCOUNT_ID: ${{secrets.AZURE_ACCOUNT_ID}}
-          AZURE_ACCOUNT_KEY: ${{secrets.AZURE_ACCOUNT_KEY}}
-          AZURE_CONTAINER_NAME: ${{secrets.AZURE_CONTAINER_NAME}}
-          AWS_REGION: ${{secrets.AWS_REGION}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
         with:
-          # Test the event's pinned proposed merge, including the current base.
+          # Test GitHub's proposed merge, including the current base.
+          # If the merge ref does not exist, checkout fails instead of testing the base.
           # External PRs cannot reach this step until the environment is approved.
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           allow-unsafe-pr-checkout: true
 
       - name: Decrypt keyfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,71 @@
+name: Secret-backed tests
+# SECURITY: External PRs require protected-environment approval before their
+# proposed merge can be checked out and executed with test credentials.
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - ".changeset/**"
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "**.md"
+      - ".changeset/**"
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: ${{ github.workflow }}--${{ github.event_name == 'pull_request_target' && format('pr#{0}', github.event.pull_request.number) || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    # Push events, merge groups, and internal PRs run without environment protection.
+    # External PRs require manual approval via the external-testing environment.
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external-testing' || '' }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          # Test GitHub's proposed merge, including the current base.
+          # If the merge ref does not exist, checkout fails instead of testing the base.
+          # External PRs cannot reach this step until the environment is approved.
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          allow-unsafe-pr-checkout: true
+
+      - name: Decrypt keyfile
+        run: ./.github/scripts/decrypt_secret.sh
+        env:
+          KEYFILE_PASSPHRASE: ${{secrets.KEYFILE_PASSPHRASE}}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-fund --no-audit
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test
+        env:
+          AWS_BUCKET: ${{secrets.AWS_BUCKET}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          AZURE_ACCOUNT_ID: ${{secrets.AZURE_ACCOUNT_ID}}
+          AZURE_ACCOUNT_KEY: ${{secrets.AZURE_ACCOUNT_KEY}}
+          AZURE_CONTAINER_NAME: ${{secrets.AZURE_CONTAINER_NAME}}
+          AWS_REGION: ${{secrets.AWS_REGION}}

--- a/packages/server/src/handlers/BaseHandler.ts
+++ b/packages/server/src/handlers/BaseHandler.ts
@@ -26,8 +26,7 @@ export class BaseHandler extends EventEmitter {
   }
 
   write(status: number, headers = {}, body?: string) {
-    const responseBody =
-      status === 204 || status === 205 || status === 304 ? null : body
+    const responseBody = status === 204 || status === 205 || status === 304 ? null : body
     const res = new Response(responseBody, {headers, status})
     if (responseBody) {
       res.headers.set(

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -272,8 +272,7 @@ export class Server extends EventEmitter {
 
   async write(context: CancellationContext, headers: Headers, status: number, body = '') {
     const isAborted = context.signal.aborted
-    const responseBody =
-      status === 204 || status === 205 || status === 304 ? null : body
+    const responseBody = status === 204 || status === 205 || status === 304 ? null : body
 
     if (responseBody !== null) {
       headers.set('Content-Length', String(Buffer.byteLength(responseBody, 'utf8')))


### PR DESCRIPTION
## Problem

Pull requests can show green CI and then make `main` red. The `Build and lint` job runs under `pull_request_target` with the default `actions/checkout` ref, so it checks the base branch instead of the proposed PR changes. The secret-backed `Tests` job does check out PR code, but it currently checks only the PR head rather than the proposed merge with the current base.

This allowed #860 to merge with formatting errors. Its PR showed green because formatting was checked on the previous `main`; both the #860 and subsequent #859 push runs then failed on `main`.

## Fix

- run unprivileged build, formatting, and lint validation from `pull_request`, where the default checkout is the proposed merge
- move secret-backed tests to a dedicated `pull_request_target` workflow and explicitly check out GitHub's proposed-merge ref, failing instead of falling back to the base if no merge exists
- keep the workflows separate so skipped jobs cannot duplicate and accidentally satisfy the required `Build and lint` or `Tests` check names
- run both jobs for `merge_group`, allowing a merge queue to validate the exact queued integration state
- retain the protected `external-testing` environment before external PR code can access test secrets
- retain the existing trusted-collaborator policy for same-repository branches; gating every internal PR is a separate security-policy decision
- apply Biome's expected formatting to the two lines that currently make `main` red

## Validation

- `biome format --error-on-warnings packages/server/src/handlers/BaseHandler.ts packages/server/src/server.ts`
- full build and test validation delegated to GitHub Actions per repository guidance
- no changeset: the package-source diff is formatting-only for behavior already covered by #860's `.changeset/shy-taxis-smile.md`

## Bootstrap note

The existing `pull_request_target` workflow definition comes from `main`, so this PR's legacy `Build and lint` check may continue to inspect the currently broken base branch. The corrected event/ref behavior takes effect once this workflow change is present on `main`; the first push run after merge validates the formatting repair.
