### PR TITLE
@tus/server: share cancellation context test helper

### DIFF
--- a/packages/server/src/test/DeleteHandler.test.ts
+++ b/packages/server/src/test/DeleteHandler.test.ts
@@ -7,6 +7,7 @@ import sinon from 'sinon'
 import {ERRORS, EVENTS, DataStore, type CancellationContext} from '@tus/utils'
 import {DeleteHandler} from '../handlers/DeleteHandler.js'
 import {MemoryLocker} from '@tus/server'
+import {createContext} from './utils.js'
 
 describe('DeleteHandler', () => {
   const path = '/test/output'
@@ -23,12 +24,7 @@ describe('DeleteHandler', () => {
       locker: new MemoryLocker(),
     })
     req = new Request(`http://example.com/${path}/1234`, {method: 'DELETE'})
-    const abortController = new AbortController()
-    context = {
-      signal: abortController.signal,
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-    }
+    context = createContext()
   })
 
   it('should 404 if no file id match', () => {

--- a/packages/server/src/test/GetHandler.test.ts
+++ b/packages/server/src/test/GetHandler.test.ts
@@ -10,6 +10,7 @@ import {GetHandler} from '../handlers/GetHandler.js'
 import {type CancellationContext, DataStore, Upload} from '@tus/utils'
 import {FileStore} from '@tus/file-store'
 import {MemoryLocker} from '@tus/server'
+import {createContext} from './utils.js'
 
 describe('GetHandler', () => {
   const path = '/test/output'
@@ -19,12 +20,7 @@ describe('GetHandler', () => {
 
   beforeEach(() => {
     req = new Request('http://localhost/test', {method: 'GET'})
-    const abortController = new AbortController()
-    context = {
-      signal: abortController.signal,
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-    }
+    context = createContext()
   })
 
   describe('test error responses', () => {

--- a/packages/server/src/test/HeadHandler.test.ts
+++ b/packages/server/src/test/HeadHandler.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon'
 import {ERRORS, DataStore, Upload, type CancellationContext} from '@tus/utils'
 import {HeadHandler} from '../handlers/HeadHandler.js'
 import {MemoryLocker} from '@tus/server'
+import {createContext} from './utils.js'
 
 describe('HeadHandler', () => {
   const path = '/test/output'
@@ -22,12 +23,7 @@ describe('HeadHandler', () => {
     req = new Request(`${url}/1234`, {
       method: 'HEAD',
     })
-    const abortController = new AbortController()
-    context = {
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-      signal: abortController.signal,
-    }
+    context = createContext()
   })
 
   it('should 404 if no file id match', () => {

--- a/packages/server/src/test/OptionsHandler.test.ts
+++ b/packages/server/src/test/OptionsHandler.test.ts
@@ -11,6 +11,7 @@ import {
   type CancellationContext,
 } from '@tus/utils'
 import {MemoryLocker, type ServerOptions} from '@tus/server'
+import {createContext} from './utils.js'
 
 describe('OptionsHandler', () => {
   const options: ServerOptions = {
@@ -25,12 +26,7 @@ describe('OptionsHandler', () => {
   let req: Request
 
   beforeEach(() => {
-    const abortController = new AbortController()
-    context = {
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-      signal: abortController.signal,
-    }
+    context = createContext()
     req = new Request(`https://example.com${options.path}/1234`, {method: 'OPTIONS'})
   })
 

--- a/packages/server/src/test/PatchHandler.test.ts
+++ b/packages/server/src/test/PatchHandler.test.ts
@@ -10,6 +10,7 @@ import sinon from 'sinon'
 import {PatchHandler} from '../handlers/PatchHandler.js'
 import {Upload, DataStore, type CancellationContext} from '@tus/utils'
 import {MemoryLocker} from '@tus/server'
+import {createContext} from './utils.js'
 
 describe('PatchHandler', () => {
   const path = '/test/output'
@@ -26,12 +27,7 @@ describe('PatchHandler', () => {
       headers: new Headers(),
       duplex: 'half',
     })
-    const abortController = new AbortController()
-    context = {
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-      signal: abortController.signal,
-    }
+    context = createContext()
   })
 
   it('should 403 if no Content-Type header', () => {
@@ -271,12 +267,7 @@ describe('PatchHandler', () => {
       body: bodyStream,
     })
 
-    const abortController = new AbortController()
-    context = {
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-      signal: abortController.signal,
-    }
+    context = createContext()
 
     let accumulatedBuffer: Buffer = Buffer.alloc(0)
 

--- a/packages/server/src/test/PostHandler.test.ts
+++ b/packages/server/src/test/PostHandler.test.ts
@@ -8,6 +8,7 @@ import sinon from 'sinon'
 import {EVENTS, Upload, DataStore, type CancellationContext} from '@tus/utils'
 import {PostHandler} from '../handlers/PostHandler.js'
 import {MemoryLocker} from '@tus/server'
+import {createContext} from './utils.js'
 
 const options = {
   path: '/test',
@@ -22,12 +23,7 @@ describe('PostHandler', () => {
   store.hasExtension.withArgs('creation-defer-length').returns(true)
 
   beforeEach(() => {
-    const abortController = new AbortController()
-    context = {
-      cancel: () => abortController.abort(),
-      abort: () => abortController.abort(),
-      signal: abortController.signal,
-    }
+    context = createContext()
   })
 
   describe('constructor()', () => {

--- a/packages/server/src/test/utils.ts
+++ b/packages/server/src/test/utils.ts
@@ -1,0 +1,11 @@
+import type {CancellationContext} from '@tus/utils'
+
+export const createContext = (): CancellationContext => {
+  const abortController = new AbortController()
+
+  return {
+    cancel: () => abortController.abort(),
+    abort: () => abortController.abort(),
+    signal: abortController.signal,
+  }
+}


### PR DESCRIPTION
Replace duplicated handler-test AbortController setup with a shared createContext helper.

related to #858
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tus/tus-node-server/pull/863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->