### PR TITLE
@tus/server: set CORS headers before early returns

### DIFF
--- a/.changeset/sweet-clouds-type.md
+++ b/.changeset/sweet-clouds-type.md
@@ -1,0 +1,5 @@
+---
+"@tus/server": patch
+---
+
+Set CORS headers before the 412 Tus-Resumable check and header-validation 400s so browsers can read those responses.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -185,6 +185,24 @@ export class Server extends EventEmitter {
     // of the protocol used by the Client or the Server.
     headers.set('Tus-Resumable', TUS_RESUMABLE)
 
+    // CORS must be set before the 412 and validation 400 returns below.
+    // Browsers otherwise treat those as a network failure and cannot read
+    // the status. GET still dispatches earlier and stays CORS-less.
+    const corsOrigin = this.getCorsOrigin(req.headers.get('origin'))
+    if (corsOrigin) {
+      headers.set('Access-Control-Allow-Origin', corsOrigin)
+    }
+    headers.set(
+      'Access-Control-Expose-Headers',
+      this.options.exposedHeaders?.length
+        ? [...HEADERS, this.options.exposedHeaders].join(', ')
+        : EXPOSED_HEADERS
+    )
+
+    if (this.options.allowedCredentials === true) {
+      headers.set('Access-Control-Allow-Credentials', 'true')
+    }
+
     if (req.method !== 'OPTIONS' && !req.headers.get('tus-resumable')) {
       return this.write(context, headers, 412, 'Tus-Resumable Required\n')
     }
@@ -213,22 +231,6 @@ export class Server extends EventEmitter {
 
     if (invalid_headers.length > 0) {
       return this.write(context, headers, 400, `Invalid ${invalid_headers.join(' ')}\n`)
-    }
-
-    // Enable CORS
-    const corsOrigin = this.getCorsOrigin(req.headers.get('origin'))
-    if (corsOrigin) {
-      headers.set('Access-Control-Allow-Origin', corsOrigin)
-    }
-    headers.set(
-      'Access-Control-Expose-Headers',
-      this.options.exposedHeaders?.length
-        ? [...HEADERS, this.options.exposedHeaders].join(', ')
-        : EXPOSED_HEADERS
-    )
-
-    if (this.options.allowedCredentials === true) {
-      headers.set('Access-Control-Allow-Credentials', 'true')
     }
 
     // Invoke the handler for the method requested

--- a/packages/server/src/test/Server.test.ts
+++ b/packages/server/src/test/Server.test.ts
@@ -152,6 +152,42 @@ describe('Server', () => {
       request(listener).post('/').expect(412, 'Tus-Resumable Required\n', done)
     })
 
+    it('should include CORS headers on 412 and validation 400 responses', async () => {
+      const origin = 'https://app.example.com'
+      const corsServer = new Server({
+        path: '/files',
+        datastore: new DataStore(),
+        allowedOrigins: [origin],
+        allowedCredentials: true,
+      })
+
+      const precondition = await corsServer.handleWeb(
+        new Request('http://localhost/files', {
+          method: 'POST',
+          headers: {Origin: origin},
+        })
+      )
+      assert.equal(precondition.status, 412)
+      assert.equal(precondition.headers.get('Access-Control-Allow-Origin'), origin)
+      assert.equal(precondition.headers.get('Access-Control-Allow-Credentials'), 'true')
+      assert.ok(precondition.headers.get('Access-Control-Expose-Headers'))
+
+      const invalid = await corsServer.handleWeb(
+        new Request('http://localhost/files', {
+          method: 'POST',
+          headers: {
+            Origin: origin,
+            'Tus-Resumable': TUS_RESUMABLE,
+            'Upload-Length': '-3',
+          },
+        })
+      )
+      assert.equal(invalid.status, 400)
+      assert.equal(invalid.headers.get('Access-Control-Allow-Origin'), origin)
+      assert.equal(invalid.headers.get('Access-Control-Allow-Credentials'), 'true')
+      assert.ok(invalid.headers.get('Access-Control-Expose-Headers'))
+    })
+
     it('should reject encoded path traversal IDs', async () => {
       const outsidePath = path.resolve(directory, '..', 'outside-victim')
       await fs.writeFile(outsidePath, 'keep me')


### PR DESCRIPTION
Move the `Access-Control-*` block above the 412 `Tus-Resumable` check and the header-validation 400s. Those returns currently happen before CORS is set, so a browser sees a network/CORS failure instead of the real status.

GET still dispatches earlier and stays CORS-less (pre-existing).

## Test plan
- [x] Unit test: 412 (missing `Tus-Resumable`) and validation 400 both include `Access-Control-Allow-Origin` for a matching origin, plus credentials and expose-headers
- CI for `@tus/server`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tus/tus-node-server/pull/873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->